### PR TITLE
refactor: :recycle: Refactor self-recursion to svelte:self to remove build warnings

### DIFF
--- a/src/components/display/verses/modes/Chapter.svelte
+++ b/src/components/display/verses/modes/Chapter.svelte
@@ -32,7 +32,6 @@
 	const urlParams = new URLSearchParams(window.location.search);
 	const startVerseParam = urlParams.get('startVerse');
 	const chapterTotalVerses = quranMetaData[$__chapterNumber].verses;
-	let Chapter; // for the "Chapter" component
 	let versesLoadType; // previous/next
 	let nextVersesProps = {};
 	let nextVersesStart;
@@ -42,8 +41,6 @@
 	function loadNextVerses() {
 		versesLoadType = 'next';
 
-		// Importing the same component to be re-used when the "Load Next Verses" button is pressed
-		import('./Chapter.svelte').then((res) => (Chapter = res.default));
 
 		// Max verses to load when the next set is requested
 		const versesToLoad = 5;
@@ -97,6 +94,6 @@
 	{/if}
 
 	{#if versesLoadType === 'next'}
-		<svelte:component this={Chapter} {...nextVersesProps} />
+		<svelte:self {...nextVersesProps} />
 	{/if}
 {/if}

--- a/src/components/display/verses/modes/FullVersesDisplay.svelte
+++ b/src/components/display/verses/modes/FullVersesDisplay.svelte
@@ -41,7 +41,6 @@
 	};
 
 	const params = new URLSearchParams(window.location.search);
-	let Individual; // for the "Individual" component
 	let nextVersesProps = {};
 	let versesLoadType; // previous/next
 	let keysArray = keys.split(',');
@@ -91,7 +90,6 @@
 
 	function loadNextVerses() {
 		try {
-			import('./FullVersesDisplay.svelte').then((res) => (Individual = res.default));
 			const lastRenderedId = document.querySelectorAll('.verse')[document.querySelectorAll('.verse').length - 1].id;
 
 			nextStartIndex = findKeyIndices(keys, lastRenderedId, maxIndexesAllowedToRender).startIndex;
@@ -256,7 +254,7 @@
 		{/if}
 
 		{#if versesLoadType === 'next'}
-			<svelte:component this={Individual} {...nextVersesProps} />
+			<svelte:self {...nextVersesProps} />
 		{/if}
 	{/if}
 {/key}


### PR DESCRIPTION
### Summary
Replace dynamic self-imports with native Svelte recursion to eliminate Vite/Rollup warnings about modules being both statically and dynamically imported, without changing runtime behavior.

### Fixed warnings
“X.svelte is dynamically imported by X.svelte but also statically imported by Y;
dynamic import will not move module into another chunk.”

### Changes

- **`src/components/display/verses/modes/Chapter.svelte`**
  - Remove `import('./Chapter.svelte')` pattern.
  - Use `<svelte:self {...nextVersesProps} />` for “load next verses” recursion.

- **`src/components/display/verses/modes/FullVersesDisplay.svelte`**
  - Remove `import('./FullVersesDisplay.svelte')` pattern.
  - Use `<svelte:self {...nextVersesProps} />` for “continue reading” recursion.


