### PR TITLE
:sparkles: feat(audio): auto-scroll highlighted words during verse playback

### DIFF
--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -7,6 +7,7 @@ import { fetchAndCacheJson } from '$utils/fetchData';
 
 // Getting the audio element
 let audio = document.querySelector('#player');
+let lastPlayedKey = null;
 
 // Function to play verse audio, either one time or multiple times
 export async function playVerseAudio(props) {
@@ -52,19 +53,7 @@ export async function playVerseAudio(props) {
 	}
 
 	// Scroll to the playing verse
-	try {
-		const element = document.getElementById(`${audioSettings.playingKey}`);
-		if (element) {
-			const y = element.offsetTop - 75;
-
-			window.scrollTo({
-				top: y,
-				behavior: 'smooth'
-			});
-		}
-	} catch (error) {
-		console.warn(error);
-	}
+	scrollElementIntoView(audioSettings.playingKey);
 
 	audio.onended = async function () {
 		audio.removeEventListener('timeupdate', wordHighlighter);
@@ -252,6 +241,11 @@ async function wordHighlighter() {
 
 		// Update the audio settings
 		__audioSettings.set(audioSettings);
+
+		if (audioSettings.playingWordKey && lastPlayedKey !== audioSettings.playingWordKey) {
+			scrollElementIntoView(audioSettings.playingWordKey);
+			lastPlayedKey = audioSettings.playingWordKey;
+		}
 	} catch (error) {
 		console.warn('wordHighlighter error:', error);
 	}
@@ -418,4 +412,19 @@ export function prepareVersesToPlay(key) {
 // Fetch timestamps for word-by-word highlighting
 async function fetchTimestampData() {
 	return await fetchAndCacheJson(`${staticEndpoint}/timestamps/timestamps.json?version=2`, 'other');
+}
+
+function scrollElementIntoView(id) {
+	try {
+		if (!id) return;
+		const element = document.getElementById(String(id));
+		if (!element) return;
+
+		element.scrollIntoView({
+			behavior: 'smooth',
+			block: 'center'
+		});
+	} catch (error) {
+		console.warn('scrollElementIntoView error:', error);
+	}
 }

--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -53,7 +53,9 @@ export async function playVerseAudio(props) {
 	}
 
 	// Scroll to the playing verse
-	scrollElementIntoView(audioSettings.playingKey);
+	if (!reciter.wbw) {
+		scrollElementIntoView(audioSettings.playingKey);
+	}
 
 	audio.onended = async function () {
 		audio.removeEventListener('timeupdate', wordHighlighter);


### PR DESCRIPTION
- Smooth scrolling to the currently highlighted word during verse audio playback. 

Previously, scrolling occurred only when a verse started. Now, as each word becomes active.

Also works in mushaf mode now.