### PR TITLE
fix: :bug: verse scrolling in audio playback for non-Arabic modes

### DIFF
--- a/src/components/display/verses/VerseOptionButtons.svelte
+++ b/src/components/display/verses/VerseOptionButtons.svelte
@@ -11,7 +11,7 @@
 	import Eye from '$svgs/Eye.svelte';
 	import Tooltip from '$ui/FlowbiteSvelte/tooltip/Tooltip.svelte';
 	import { playVerseAudio, resetAudioSettings, showAudioModal, playButtonHandler, prepareVersesToPlay } from '$utils/audioController';
-	import { __currentPage, __userSettings, __audioSettings, __verseKey, __userNotes, __notesModalVisible, __playButtonsFunctionality, __displayType } from '$utils/stores';
+	import { __currentPage, __userSettings, __audioSettings, __verseKey, __userNotes, __notesModalVisible, __playButtonsFunctionality, __displayType, __verseWordBlocks } from '$utils/stores';
 	import { updateSettings } from '$utils/updateSettings';
 	import { term } from '$utils/terminologies';
 	import { quranMetaData } from '$data/quranMeta';
@@ -58,7 +58,12 @@
 
 	// Function to toggle words block for display mode #7
 	function wordsBlockToggler(chapter, verse) {
-		document.querySelector(`#verse-${chapter}-${verse}-words`).classList.toggle('hidden');
+		const key = `${chapter}:${verse}`;
+		__verseWordBlocks.update(blocks => {
+			blocks[key] = !blocks[key];
+			document.querySelector(`#verse-${chapter}-${verse}-words`).classList.toggle('hidden');
+			return blocks;
+		});
 	}
 </script>
 

--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { quranMetaData } from '$data/quranMeta';
-import { __reciter, __translationReciter, __playbackSpeed, __audioSettings, __audioModalVisible, __currentPage, __chapterNumber, __keysToFetch } from '$utils/stores';
+import { __reciter, __translationReciter, __playbackSpeed, __audioSettings, __audioModalVisible, __currentPage, __chapterNumber, __keysToFetch, __displayType, __verseWordBlocks } from '$utils/stores';
 import { staticEndpoint, wordsAudioURL } from '$data/websiteSettings';
 import { selectableReciters, selectableTranslationReciters, selectablePlaybackSpeeds, selectableAudioDelays } from '$data/options';
 import { fetchAndCacheJson } from '$utils/fetchData';
@@ -53,7 +53,7 @@ export async function playVerseAudio(props) {
 	}
 
 	// Scroll to the playing verse
-	if (!reciter.wbw) {
+	if (!reciter.wbw || (get(__displayType) === 7 && !get(__verseWordBlocks)[audioSettings.playingKey])) {
 		scrollElementIntoView(audioSettings.playingKey);
 	}
 

--- a/src/utils/stores.js
+++ b/src/utils/stores.js
@@ -61,7 +61,8 @@ let __websiteOnline,
 	__keysToFetch,
 	__wordMorphologyOnClick,
 	__homepageExtrasPanelVisible,
-	__wideWesbiteLayoutEnabled;
+	__wideWesbiteLayoutEnabled,
+	__verseWordBlocks;
 
 if (browser) {
 	const userSettings = JSON.parse(localStorage.getItem('userSettings'));
@@ -227,6 +228,9 @@ if (browser) {
 
 	// to store the website wide layout option
 	__wideWesbiteLayoutEnabled = writable(userSettings.displaySettings.wideWesbiteLayoutEnabled);
+
+	// to store the visibility state of word blocks per verse
+	__verseWordBlocks = writable({});
 }
 
 export {
@@ -290,5 +294,6 @@ export {
 	__keysToFetch,
 	__wordMorphologyOnClick,
 	__homepageExtrasPanelVisible,
-	__wideWesbiteLayoutEnabled
+	__wideWesbiteLayoutEnabled,
+	__verseWordBlocks
 };


### PR DESCRIPTION
# Description 

This PR fixes the scrolling behavior during audio playback in Translation/Transliteration display mode.

## Problem

- In Translation/Transliteration mode (display type 7), there's no word-by-word highlighting like in Arabic modes
- The current scrolling logic only triggers when `!reciter.wbw`, this causes inconsistent scrolling behavior during audio playback

# Changes

- Added __verseWordBlocks store to track word visibility state per verse
- Modified wordsBlockToggler to sync DOM changes with store state
- Updated scrolling condition in playVerseAudio to include Translation/Transliteration mode

# Related Issue
Closes #331 - Audio playback scrolling issue in non-Arabic display modes