### PR TITLE
Handle touch toggle on bookmark menu

### DIFF
--- a/src/components/display/BookmarkCard.svelte
+++ b/src/components/display/BookmarkCard.svelte
@@ -82,7 +82,7 @@
 	</a>
 
 	<!-- Options menu button -->
-	<button id="bookmark-menu-{bookmark.replace(':', '-')}" bind:this={buttonElement} on:click|stopPropagation={toggleDropdown} class="absolute top-2 right-2 p-1 rounded-full {window.theme('hover')} opacity-70 hover:opacity-100 transition-opacity z-10 focus:outline-none" aria-label={dropdownOpen ? 'Close menu' : 'Open options menu'} aria-expanded={dropdownOpen} aria-haspopup="true">
+	<button id="bookmark-menu-{bookmark.replace(':', '-')}" bind:this={buttonElement} on:click|stopPropagation={toggleDropdown} on:touchend|preventDefault|stopPropagation={toggleDropdown} class="absolute top-2 right-2 p-1 rounded-full {window.theme('hover')} opacity-70 hover:opacity-100 transition-opacity z-10 focus:outline-none" aria-label={dropdownOpen ? 'Close menu' : 'Open options menu'} aria-expanded={dropdownOpen} aria-haspopup="true">
 		<DotsHorizontal size={5} />
 	</button>
 </div>


### PR DESCRIPTION
## Summary
- add touchend handler to bookmark menu button to toggle dropdown

## Testing
- manual: touch bookmark menu button to open/close dropdown