### PR TITLE
Add 'topics' to current page check in VerseOptionButtons

### DIFF
--- a/src/components/display/verses/VerseOptionButtons.svelte
+++ b/src/components/display/verses/VerseOptionButtons.svelte
@@ -31,7 +31,7 @@
 		if ($__audioSettings.isPlaying) return resetAudioSettings({ location: 'end' });
 
 		// For these pages, perform action depending on the play button functionality set by the user
-		if (['chapter', 'mushaf', 'supplications', 'bookmarks', 'juz', 'hizb'].includes($__currentPage)) {
+		if (['chapter', 'mushaf', 'supplications', 'bookmarks', 'juz', 'hizb', 'topics'].includes($__currentPage)) {
 			switch ($__playButtonsFunctionality.verse) {
 				// Play Verse
 				case 1:


### PR DESCRIPTION
Assalam-o-Alaikum!.

Playing a verse from the Topics page always plays in Arabic, ignoring Advanced Play Settings. This is because 'topics' is missing from the supported pages list in 'VerseOptionButtons.svelte', causing it to fall through to the 'else' branch with hardcoded 'language': 'arabic'.
