### PR TITLE
feat: real audio pause/resume

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -249,7 +249,5 @@
 		</script>
 
 		<div style="display: contents">%sveltekit.body%</div>
-		<!-- global audio player -->
-		<audio id="player"></audio>
 	</body>
 </html>

--- a/src/components/audio/AudioPlayer.svelte
+++ b/src/components/audio/AudioPlayer.svelte
@@ -1,0 +1,16 @@
+<script>
+	import { onMount } from 'svelte';
+	import { registerAudioElement } from '$utils/audioController';
+
+	// The single <audio> element used for all verse and word playback. It lives in this
+	// component (not app.html) so the controller can own its lifecycle and receive the node
+	// via registerAudioElement() instead of querying the DOM. Mounted outside the {#key}
+	// block in +layout.svelte so it survives navigation. (Reactive telemetry bindings —
+	// currentTime/duration — will be added with the feature that consumes them.)
+	let player;
+
+	onMount(() => registerAudioElement(player));
+</script>
+
+<!-- id="player" retained as a safety net for the controller's querySelector fallback -->
+<audio id="player" bind:this={player}></audio>

--- a/src/components/display/verses/VerseOptionButtons.svelte
+++ b/src/components/display/verses/VerseOptionButtons.svelte
@@ -10,8 +10,8 @@
 	import DotsHorizontal from '$svgs/DotsHorizontal.svelte';
 	import Eye from '$svgs/Eye.svelte';
 	import Tooltip from '$ui/FlowbiteSvelte/tooltip/Tooltip.svelte';
-	import { playVerseAudio, resetAudioSettings, showAudioModal, playButtonHandler, prepareVersesToPlay } from '$utils/audioController';
-	import { __currentPage, __userSettings, __audioSettings, __verseKey, __userNotes, __notesModalVisible, __playButtonsFunctionality, __displayType, __verseWordBlocks } from '$utils/stores';
+	import { playVerseAudio, resetAudioSettings, showAudioModal, playButtonHandler, prepareVersesToPlay, togglePlayPause } from '$utils/audioController';
+	import { __currentPage, __userSettings, __audioSettings, __verseKey, __userNotes, __notesModalVisible, __playButtonsFunctionality, __displayType, __verseWordBlocks, __playback } from '$utils/stores';
 	import { updateSettings } from '$utils/updateSettings';
 	import { term } from '$utils/terminologies';
 	import { quranMetaData } from '$data/quranMeta';
@@ -27,8 +27,12 @@
 	$: userBookmarks = JSON.parse($__userSettings).userBookmarks;
 
 	async function audioHandler(key) {
-		// Stop any audio if something is playing
-		if ($__audioSettings.isPlaying) return resetAudioSettings({ location: 'end' });
+		// If a session is active for THIS verse, toggle pause/resume instead of restarting it
+		if ($__playback !== 'idle') {
+			if ($__audioSettings.playingKey === key) return togglePlayPause();
+			// A different verse is active — stop it first, then start this one
+			resetAudioSettings({ location: 'end' });
+		}
 
 		// For these pages, perform action depending on the play button functionality set by the user
 		if (['chapter', 'mushaf', 'supplications', 'bookmarks', 'juz', 'hizb', 'topics'].includes($__currentPage)) {
@@ -88,7 +92,7 @@
 			<!-- play verse button -->
 			<button on:click={() => audioHandler(key)} class={buttonClasses} aria-label="Play">
 				<div>
-					<svelte:component this={$__audioSettings.isPlaying && $__audioSettings.playingKey === key ? Pause : Play} size={3.5} />
+					<svelte:component this={$__playback !== 'idle' && $__audioSettings.playingKey === key ? Pause : Play} size={3.5} />
 				</div>
 			</button>
 			<Tooltip arrow={false} type="light" placement="top" class="z-30 hidden md:block font-normal">Play</Tooltip>

--- a/src/components/ui/BottomToolbar/AudioButton.svelte
+++ b/src/components/ui/BottomToolbar/AudioButton.svelte
@@ -2,42 +2,46 @@
 	import PlaySolid from '$svgs/PlaySolid.svelte';
 	import PauseSolid from '$svgs/PauseSolid.svelte';
 	import Tooltip from '$ui/FlowbiteSvelte/tooltip/Tooltip.svelte';
-	import { playButtonHandler, setVersesToPlay, resetAudioSettings } from '$utils/audioController';
-	import { __currentPage, __audioSettings, __fullVersesDisplayKeys } from '$utils/stores';
+	import { playButtonHandler, setVersesToPlay, togglePlayPause } from '$utils/audioController';
+	import { __currentPage, __audioSettings, __fullVersesDisplayKeys, __playback } from '$utils/stores';
 	import { checkOnlineAndAlert } from '$utils/offlineModeHandler';
+
+	// Reactive transport flags derived from the single playback status store
+	$: isPlaying = $__playback === 'playing';
+	$: isActive = $__playback !== 'idle';
 
 	// Toggle audio playback: stop if playing, or start from the first verse on the page
 	async function audioHandler() {
+		// An active session just toggles pause/resume — no queue rebuild, no network, works offline
+		if (isActive) return togglePlayPause();
+
+		// Idle: starting a fresh session needs the audio files, so check connectivity first
 		if (!(await checkOnlineAndAlert())) return;
 
-		if ($__audioSettings.isPlaying) {
-			resetAudioSettings({ location: 'end' });
-		} else {
-			// For juz/hizb pages, restrict playback to verses within that section
-			if (['juz', 'hizb'].includes($__currentPage)) {
-				setVersesToPlay({ verses: $__fullVersesDisplayKeys.split(',') });
-			}
-			// For all other pages, play every verse visible on the page
-			else {
-				setVersesToPlay({ allVersesOnPage: true });
-			}
-
-			// Begin playback from the first verse (verse or word mode, per user settings)
-			playButtonHandler(window.versesToPlayArray[0]);
+		// For juz/hizb pages, restrict playback to verses within that section
+		if (['juz', 'hizb'].includes($__currentPage)) {
+			setVersesToPlay({ verses: $__fullVersesDisplayKeys.split(',') });
 		}
+		// For all other pages, play every verse visible on the page
+		else {
+			setVersesToPlay({ allVersesOnPage: true });
+		}
+
+		// Begin playback from the first verse (verse or word mode, per user settings)
+		playButtonHandler(window.versesToPlayArray[0]);
 	}
 </script>
 
 <!-- play/pause button -->
 <div class="flex items-center justify-center">
-	<button type="button" title={$__audioSettings.isPlaying ? 'Pause' : 'Play'} on:click={() => audioHandler()} class="inline-flex flex-col items-center justify-center w-12 h-12 rounded-full group focus:border-theme-accent focus:ring-theme-accent bg-theme-accent/15" data-umami-event="Toolbar Play Button">
-		<span><svelte:component this={$__audioSettings.isPlaying ? PauseSolid : PlaySolid} size={5} /></span>
-		<span class="sr-only">{$__audioSettings.isPlaying ? 'Pause' : 'Play'}</span>
+	<button type="button" title={isPlaying ? 'Pause' : 'Play'} on:click={() => audioHandler()} class="inline-flex flex-col items-center justify-center w-12 h-12 rounded-full group focus:border-theme-accent focus:ring-theme-accent bg-theme-accent/15" data-umami-event="Toolbar Play Button">
+		<span><svelte:component this={isPlaying ? PauseSolid : PlaySolid} size={5} /></span>
+		<span class="sr-only">{isPlaying ? 'Pause' : 'Play'}</span>
 
 		<!-- show badge when a verse is playing -->
-		{#if $__audioSettings.isPlaying && $__audioSettings.audioType === 'verse'}
+		{#if isActive && $__audioSettings.audioType === 'verse'}
 			<div class="absolute inline-flex items-center justify-center z-30 text-xs px-2 rounded-3xl -top-3 border bg-theme-bg border-theme-accent/20">{$__audioSettings.playingKey}</div>
 		{/if}
 	</button>
 </div>
-<Tooltip arrow={false} type="light" class="hidden md:block font-normal">{$__audioSettings.isPlaying ? 'Pause' : 'Play'}</Tooltip>
+<Tooltip arrow={false} type="light" class="hidden md:block font-normal">{isPlaying ? 'Pause' : 'Play'}</Tooltip>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 	import CopyShareVerseModal from '$ui/Modals/CopyShareVerseModal.svelte';
 	import ConfirmationAlertModal from '$ui/Modals/ConfirmationAlertModal.svelte';
 	import FavoriteChaptersModal from '$ui/Modals/FavoriteChaptersModal.svelte';
+	import AudioPlayer from '$src/components/audio/AudioPlayer.svelte';
 
 	import { __userSettings, __currentPage, __chapterNumber, __settingsDrawerHidden, __wakeLockEnabled, __fontType, __wordTranslation, __mushafMinimalModeEnabled, __topNavbarVisible, __bottomToolbarVisible, __displayType, __wideWesbiteLayoutEnabled, __signLanguageModeEnabled, __wordTransliterationEnabled } from '$utils/stores';
 	import { debounce } from '$utils/debounce';
@@ -195,6 +196,9 @@
 	<CopyShareVerseModal />
 	<FavoriteChaptersModal />
 	<ConfirmationAlertModal />
+
+	<!-- global audio player — kept outside the keyed block so it survives navigation -->
+	<AudioPlayer />
 
 	{#key $page.url.pathname}
 		<div in:fade={{ duration: 300 }}>

--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -1,13 +1,15 @@
 import { get } from 'svelte/store';
 import { quranMetaData } from '$data/quranMeta';
-import { __reciter, __translationReciter, __playbackSpeed, __audioSettings, __audioModalVisible, __currentPage, __chapterNumber, __keysToFetch, __displayType, __verseWordBlocks } from '$utils/stores';
+import { __reciter, __translationReciter, __playbackSpeed, __audioSettings, __audioModalVisible, __currentPage, __chapterNumber, __keysToFetch, __displayType, __verseWordBlocks, __playback } from '$utils/stores';
 import { staticEndpoint, wordsAudioURL } from '$data/websiteSettings';
 import { selectableReciters, selectableTranslationReciters, selectablePlaybackSpeeds, selectableAudioDelays } from '$data/options';
 import { fetchAndCacheJson } from '$utils/fetchData';
 import { checkOnlineAndAlert } from '$utils/offlineModeHandler';
 
-// <audio> element used for all verse and word playback
-let audio = document.querySelector('#player');
+// <audio> element used for all verse and word playback. Owned by AudioPlayer.svelte and
+// handed to this module via registerAudioElement() on mount, so it is null until then —
+// don't query the DOM at module load (the element no longer lives in app.html).
+let audio = null;
 
 // Tracks the last highlighted word to avoid redundant scrolls
 let lastPlayedKey = null;
@@ -26,6 +28,40 @@ let wordsInVerseCache = {};
 
 // Prevents overlapping executions of the wordHighlighter handler
 let isHighlighting = false;
+
+// Receives the shared <audio> node from AudioPlayer.svelte on mount, so the rest of this
+// module can drive playback without querying the DOM for #player.
+export function registerAudioElement(element) {
+	audio = element;
+}
+
+// Shared loader for verse and word playback: fetches (or pulls from cache) the audio at
+// `url`, swaps it into the shared element, and starts playback. Callers always run
+// resetAudioSettings() first (which detaches + revokes the previous blob), so there is no
+// stale src to collide with. Returns false when the request is aborted (offline/uncached) or
+// superseded by a newer one, so the caller can bail before touching playback state.
+async function loadAndPlay(url) {
+	const requestId = ++activeAudioRequestId;
+	const audioUrl = await getAudioUrl(url);
+
+	if (!audioUrl) return false;
+
+	// A newer request superseded this one while awaiting — discard the now-orphan blob
+	if (requestId !== activeAudioRequestId) {
+		if (audioUrl.startsWith('blob:')) URL.revokeObjectURL(audioUrl);
+		return false;
+	}
+
+	// Track the blob so resetAudioSettings can revoke it once this verse/word is done
+	lastBlobUrl = audioUrl.startsWith('blob:') ? audioUrl : null;
+
+	audio.src = audioUrl;
+	audio.currentTime = 0;
+	audio.load();
+	audio.playbackRate = selectablePlaybackSpeeds[get(__playbackSpeed)].speed;
+	audio.play();
+	return true;
+}
 
 // Function to play verse audio, either one time or multiple times
 export async function playVerseAudio(props) {
@@ -56,39 +92,12 @@ export async function playVerseAudio(props) {
 		getAudioUrl(`${reciterAudioUrl}/${nextVerseFileName}`, false);
 	}
 
-	// Tag this request with a unique ID to detect if a newer request has superseded it
-	const requestId = ++activeAudioRequestId;
-	const audioUrl = await getAudioUrl(`${reciterAudioUrl}/${currentVerseFileName}`);
+	// Load + start; bail if offline/uncached or superseded by a newer request
+	if (!(await loadAndPlay(`${reciterAudioUrl}/${currentVerseFileName}`))) return;
 
-	// If URL is missing (e.g. offline + not cached), abort before touching the player state
-	if (!audioUrl) return;
-
-	// If a newer audio request was made while we were awaiting, discard this result
-	if (requestId !== activeAudioRequestId) {
-		// Clean up the blob URL to avoid memory leaks if one was created
-		if (audioUrl?.startsWith('blob:')) {
-			URL.revokeObjectURL(audioUrl);
-		}
-		return;
-	}
-
-	// Release the previous blob URL from memory before switching to the new one
-	if (lastBlobUrl) {
-		URL.revokeObjectURL(lastBlobUrl);
-	}
-
-	// Track the new blob URL so we can revoke it later when moving to the next verse
-	lastBlobUrl = audioUrl?.startsWith('blob:') ? audioUrl : null;
-
-	audio.src = audioUrl;
-	audio.currentTime = 0;
-	audio.load();
-	audio.playbackRate = selectablePlaybackSpeeds[get(__playbackSpeed)].speed;
-	audio.play();
-
-	audioSettings.isPlaying = true;
 	audioSettings.playingKey = props.key;
 	audioSettings.audioType = 'verse';
+	__playback.set('playing');
 
 	// Attach word highlighting function for supported reciters
 	if (props.language === 'arabic' && reciter.wbw) {
@@ -177,40 +186,13 @@ export async function playWordAudio(props) {
 		console.warn(error);
 	}
 
-	// Tag this request with a unique ID to detect if a newer request has superseded it
-	const requestId = ++activeAudioRequestId;
-	const audioUrl = await getAudioUrl(`${wordsAudioURL}/${currentWordFileName}?version=2`);
+	// Load + start; bail if offline/uncached or superseded by a newer request
+	if (!(await loadAndPlay(`${wordsAudioURL}/${currentWordFileName}?version=2`))) return;
 
-	// If URL is missing (e.g. offline + not cached), abort before touching the player state
-	if (!audioUrl) return;
-
-	// If a newer audio request was made while we were awaiting, discard this result
-	if (requestId !== activeAudioRequestId) {
-		// Clean up the blob URL to avoid memory leaks if one was created
-		if (audioUrl?.startsWith('blob:')) {
-			URL.revokeObjectURL(audioUrl);
-		}
-		return;
-	}
-
-	// Release the previous blob URL from memory before switching to the new one
-	if (lastBlobUrl) {
-		URL.revokeObjectURL(lastBlobUrl);
-	}
-
-	// Track the new blob URL so we can revoke it later when moving to the next word
-	lastBlobUrl = audioUrl?.startsWith('blob:') ? audioUrl : null;
-
-	audio.src = audioUrl;
-	audio.currentTime = 0;
-	audio.load();
-	audio.playbackRate = selectablePlaybackSpeeds[get(__playbackSpeed)].speed;
-	audio.play();
-
-	audioSettings.isPlaying = true;
 	audioSettings.audioType = 'word';
 	audioSettings.playingKey = `${wordChapter}:${wordVerse}`;
 	audioSettings.playingWordKey = `${props.key}`;
+	__playback.set('playing');
 
 	// For debugging purposes, needs not be removed
 	console.log('playing word', '-', audioSettings.playingWordKey);
@@ -271,8 +253,8 @@ export function resetAudioSettings(props) {
 		// Stop playback and reset position
 		audio.pause();
 		audio.currentTime = 0;
-		audioSettings.isPlaying = false;
 		audioSettings.playingWordKey = null;
+		__playback.set('idle');
 
 		// If reset was triggered at the end of a playlist, clear the verses queue
 		if (props?.location === 'end') {
@@ -282,8 +264,12 @@ export function resetAudioSettings(props) {
 		// Invalidate any in-flight audio requests so they get discarded when they resolve
 		activeAudioRequestId++;
 
-		// Release the current blob URL from memory
+		// Detach the blob from the element BEFORE revoking it, so the element is never left
+		// pointing at a revoked URL — that dangling reference is what logged ERR_FILE_NOT_FOUND
+		// when advancing or stopping mid-playback.
 		if (lastBlobUrl) {
+			audio.removeAttribute('src');
+			audio.load();
 			URL.revokeObjectURL(lastBlobUrl);
 			lastBlobUrl = null;
 		}
@@ -304,6 +290,31 @@ export function resetAudioSettings(props) {
 	}
 }
 
+// Pause WITHOUT tearing anything down — keeps src, currentTime, the queue, the blob, and
+// the ended/timeupdate listeners intact, so resuming continues seamlessly. Internal: the UI
+// goes through togglePlayPause().
+function pause() {
+	if (!audio) return;
+	audio.pause();
+	__playback.set('paused');
+}
+
+// Resume from the exact paused position — no refetch or seek, the element still holds the
+// decoded audio. play() is imperative so we can catch the autoplay/abort rejection.
+function resume() {
+	if (!audio) return;
+	audio.play().catch((error) => console.warn(error));
+	__playback.set('playing');
+}
+
+// Toggle pause/resume for the current session. Does nothing when idle — starting a fresh
+// session (building the queue) is the caller's responsibility.
+export function togglePlayPause() {
+	const status = get(__playback);
+	if (status === 'playing') pause();
+	else if (status === 'paused') resume();
+}
+
 // Show audio modal with key
 export function showAudioModal(key) {
 	resetAudioSettings();
@@ -319,7 +330,7 @@ export async function wordAudioController(props) {
 	const chapter = +props.key.split(':')[0];
 	const verse = +props.key.split(':')[1];
 
-	if (audioSettings.isPlaying && audioSettings.audioType === 'verse' && reciter.wbw) {
+	if (get(__playback) !== 'idle' && audioSettings.audioType === 'verse' && reciter.wbw) {
 		const timestampData = await fetchTimestampData();
 		const verseTimestamp = timestampData.data[chapter][verse][reciter.id];
 		const wordTimestamp = verseTimestamp.split('|')[props.key.split(':')[2]];

--- a/src/utils/stores.js
+++ b/src/utils/stores.js
@@ -31,6 +31,7 @@ let __currentPage,
 	__mushafPageDivisions,
 	__wordTooltip,
 	__audioSettings,
+	__playback,
 	__morphologyKey,
 	__firstVerseOnPage,
 	__audioModalVisible,
@@ -152,6 +153,9 @@ if (browser) {
 	// to store all the audio settings
 	__audioSettings = writable(userSettings.audioSettings);
 
+	// to store the live playback status: 'idle' | 'playing' | 'paused' (runtime only, not persisted)
+	__playback = writable('idle');
+
 	// to store the morphology verse/word key
 	__morphologyKey = writable(null);
 
@@ -258,6 +262,7 @@ export {
 	__mushafPageDivisions,
 	__wordTooltip,
 	__audioSettings,
+	__playback,
 	__morphologyKey,
 	__firstVerseOnPage,
 	__audioModalVisible,

--- a/src/utils/toggleNavbarToolbarOnScroll.js
+++ b/src/utils/toggleNavbarToolbarOnScroll.js
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store';
-import { __currentPage, __topNavbarVisible, __bottomToolbarVisible, __audioSettings } from '$utils/stores';
+import { __currentPage, __topNavbarVisible, __bottomToolbarVisible, __audioSettings, __playback } from '$utils/stores';
 
 // Threshold (px) before navbars hide when scrolling down
 const scrollHideThreshold = 100;
@@ -91,13 +91,13 @@ function hideNavbars() {
 	if (window.scrollY <= scrollHideThreshold) return;
 
 	const currentPage = get(__currentPage);
-	const { isPlaying, audioType } = get(__audioSettings);
+	const { audioType } = get(__audioSettings);
 
 	// On juz/hizb pages, keep the top navbar visible — only hide the bottom toolbar
 	const shouldShowTopNavbar = alwaysShowTopNavbarPages.includes(currentPage);
 
 	// Keep the bottom toolbar visible if verse audio is actively playing
-	const shouldShowBottomToolbar = isPlaying && audioType === 'verse';
+	const shouldShowBottomToolbar = get(__playback) !== 'idle' && audioType === 'verse';
 
 	__topNavbarVisible.set(shouldShowTopNavbar);
 	__bottomToolbarVisible.set(shouldShowBottomToolbar);


### PR DESCRIPTION
## What
Replaces the binary play/stop toggle with real pause/resume: pausing holds the position and resuming continues from there instead of restarting the verse from the beginning.

## Why
The play button only modelled play vs. stop — "unpausing" rebuilt the queue and replayed the verse from `currentTime = 0`. Nothing stored the position and there was no bare `audio.play()` resume path.

## How
- **`__playback` status store** (`idle | playing | paused`) in `stores.js` as the single source of truth for transport state, read inline like `__currentPage` (no `derived`, no separate module).
- **`<audio>` element moved into `AudioPlayer.svelte`**, registered with the controller and mounted outside the routed `{#key}` block so it survives navigation (drops the `document.querySelector('#player')` lookups).
- **`pause` / `resume` / `togglePlayPause`** do a bare element pause/play with no teardown; `resetAudioSettings` is the stop.
- **De-duplicated `playVerseAudio` / `playWordAudio`** onto a shared `loadAndPlay` helper.
- **Fixed a blob-revoke race** that logged `ERR_FILE_NOT_FOUND` on verse transitions (detach `src` before revoking).
- Bottom toolbar stays visible while paused.

## Testing
- `npm run lint:unused` clean; `npm run build` succeeds.
- Verified in-browser: start → pause (holds position, keeps the blob) → resume (continues, no refetch) → auto-advance → stop; 0 console errors.

## Notes
- The toolbar button is now pause/resume (not stop); a session ends via navigation, opening a modal, or starting a different verse.
- Intentionally left out of scope: the `window.versesToPlayArray` global queue, the `get/mutate/set` pattern on `__audioSettings`, and the DOM-scraped queue in `setVersesToPlay`.
