### PR TITLE
fix: use word count for reading progress

### DIFF
--- a/src/components/display/layouts/Continuous.svelte
+++ b/src/components/display/layouts/Continuous.svelte
@@ -3,7 +3,7 @@
 
 	import WordsBlock from '$display/verses/WordsBlock.svelte';
 	import PageDivider from '$display/verses/PageDivider.svelte';
-	import { updateSettings } from '$utils/updateSettings';
+	import { trackReadingPosition } from '$utils/trackReadingPosition';
 	import { inview } from 'svelte-inview';
 </script>
 
@@ -11,7 +11,7 @@
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse inline py-2 group verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div id={key} class="verse inline py-2 group verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_change={(event) => trackReadingPosition(value.meta, event.detail)}>
 		<WordsBlock {key} {value} />
 	</div>
 {/if}

--- a/src/components/display/layouts/Normal.svelte
+++ b/src/components/display/layouts/Normal.svelte
@@ -6,7 +6,7 @@
 	import VerseTranslations from '$display/verses/VerseTranslations.svelte';
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
-	import { updateSettings } from '$utils/updateSettings';
+	import { trackReadingPosition } from '$utils/trackReadingPosition';
 	import { inview } from 'svelte-inview';
 </script>
 
@@ -14,7 +14,7 @@
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_change={(event) => trackReadingPosition(value.meta, event.detail)}>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/display/layouts/SideBySide.svelte
+++ b/src/components/display/layouts/SideBySide.svelte
@@ -6,7 +6,7 @@
 	import VerseTranslations from '$display/verses/VerseTranslations.svelte';
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
-	import { updateSettings } from '$utils/updateSettings';
+	import { trackReadingPosition } from '$utils/trackReadingPosition';
 	import { __verseTranslations } from '$utils/stores';
 	import { inview } from 'svelte-inview';
 
@@ -18,7 +18,7 @@
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_change={(event) => trackReadingPosition(value.meta, event.detail)}>
 		<VerseOptionButtons {key} {value} />
 
 		<div class="grid {gridCols} gap-x-8">

--- a/src/components/display/layouts/TranslationTransliteration.svelte
+++ b/src/components/display/layouts/TranslationTransliteration.svelte
@@ -6,7 +6,7 @@
 	import VerseTranslations from '$display/verses/VerseTranslations.svelte';
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
-	import { updateSettings } from '$utils/updateSettings';
+	import { trackReadingPosition } from '$utils/trackReadingPosition';
 	import { inview } from 'svelte-inview';
 </script>
 
@@ -14,7 +14,7 @@
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_change={(event) => trackReadingPosition(value.meta, event.detail)}>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/display/layouts/WordByWord.svelte
+++ b/src/components/display/layouts/WordByWord.svelte
@@ -6,7 +6,7 @@
 	import VerseTranslations from '$display/verses/VerseTranslations.svelte';
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
-	import { updateSettings } from '$utils/updateSettings';
+	import { trackReadingPosition } from '$utils/trackReadingPosition';
 	import { inview } from 'svelte-inview';
 </script>
 
@@ -14,7 +14,7 @@
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_change={(event) => trackReadingPosition(value.meta, event.detail)}>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/ui/Navbar.svelte
+++ b/src/components/ui/Navbar.svelte
@@ -5,7 +5,7 @@
 	import Mecca from '$svgs/Mecca.svelte';
 	import Madinah from '$svgs/Madinah.svelte';
 	import { quranMetaData } from '$data/quranMeta';
-	import { __chapterNumber, __currentPage, __lastRead, __topNavbarVisible, __pageNumber, __morphologyKey, __mushafPageDivisions, __siteNavigationModalVisible, __quranNavigationModalVisible, __wideWesbiteLayoutEnabled, __fullVersesDisplayKeys } from '$utils/stores';
+	import { __chapterNumber, __currentPage, __lastRead, __topNavbarVisible, __pageNumber, __morphologyKey, __mushafPageDivisions, __siteNavigationModalVisible, __quranNavigationModalVisible, __wideWesbiteLayoutEnabled, __fullVersesDisplayKeys, __chapterData, __verseKeyData } from '$utils/stores';
 	import { term } from '$utils/terminologies';
 	import { getWebsiteWidth } from '$utils/getWebsiteWidth';
 	import { page } from '$app/stores';
@@ -43,32 +43,66 @@
 	$: revelationTerm = term(revelation.termKey);
 	$: RevelationIcon = revelation.Icon;
 
-	// Calculates reading progress (0–100%) — by verse fraction on chapter pages, or by position within the displayed verse keys on all other pages.
+	// cumulativeWords[verse] = number of words from the start of the chapter to that verse.
+	$: chapterWordCounts = (() => {
+		if ($__currentPage !== 'chapter' || !$__chapterData) return null;
+
+		const cumulativeWords = [0];
+		let total = 0;
+
+		for (let verse = 1; verse <= quranMetaData[$__chapterNumber].verses; verse++) {
+			total += $__chapterData[`${$__chapterNumber}:${verse}`]?.meta.words ?? 0;
+			cumulativeWords[verse] = total;
+		}
+
+		return { cumulativeWords, total };
+	})();
+
 	$: readingProgress = (() => {
 		// No progress if the user hasn't started reading yet
 		if (!Object.prototype.hasOwnProperty.call($__lastRead, 'chapter')) return 0;
 
-		// On the chapter page, progress = verses read / total verses in chapter
+		// progress = words read / total words in chapter
 		if ($__currentPage === 'chapter') {
-			return ($__lastRead.verse / quranMetaData[$__lastRead.chapter].verses) * 100;
+			if ($__lastRead.chapter !== $__chapterNumber || !chapterWordCounts?.total) return 0;
+
+			return ((chapterWordCounts.cumulativeWords[$__lastRead.verse] ?? 0) / chapterWordCounts.total) * 100;
 		}
 
-		// On other pages, progress is derived from the ordered list of displayed verse keys
 		if ($__fullVersesDisplayKeys?.length) {
 			// The store may hold a comma-separated string or an array — normalise to array
-			const keys = typeof $__fullVersesDisplayKeys === 'string' ? $__fullVersesDisplayKeys.split(',') : $__fullVersesDisplayKeys;
+			const verseKeys = typeof $__fullVersesDisplayKeys === 'string' ? $__fullVersesDisplayKeys.split(',') : $__fullVersesDisplayKeys;
 
-			// Find the last key that is at or before the user's current read position
-			const index = keys.findLastIndex((k) => {
-				const [kChap, kVerse] = k.split(':').map(Number);
-				return kChap < $__lastRead.chapter || (kChap === $__lastRead.chapter && kVerse <= $__lastRead.verse);
-			});
+			// A juz or hizb spans several chapters, so positions have to be compared across them.
+			// Multiply the chapter number by 1000 to ensure that the verse number doesn't affect the comparison.
+			const positionOf = (chapter, verse) => chapter * 1000 + verse;
+			const keyPosition = (verseKey) => positionOf(...verseKey.split(':').map(Number));
+
+			const lastReadPosition = positionOf($__lastRead.chapter, $__lastRead.verse);
+			if (lastReadPosition < keyPosition(verseKeys[0]) || lastReadPosition > keyPosition(verseKeys[verseKeys.length - 1])) return 0;
+
+			// Find the last key at or before the read position — it marks where to stop counting words
+			const index = verseKeys.findLastIndex((verseKey) => keyPosition(verseKey) <= lastReadPosition);
 
 			// If no key is before the last read position, the user hasn't reached this page yet
 			if (index === -1) return 0;
 
-			// Progress = position of last read key / total keys on this page
-			return ((index + 1) / keys.length) * 100;
+			// Progress = words up to the last read key / total words on this page
+			if ($__verseKeyData) {
+				let readWords = 0;
+				let totalWords = 0;
+
+				verseKeys.forEach((verseKey, keyIndex) => {
+					const words = $__verseKeyData[verseKey]?.words ?? 0;
+					totalWords += words;
+					if (keyIndex <= index) readWords += words;
+				});
+
+				if (totalWords > 0) return (readWords / totalWords) * 100;
+			}
+
+			// Fall back to the key position while the word counts are still loading
+			return ((index + 1) / verseKeys.length) * 100;
 		}
 
 		return 0;

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -1,6 +1,6 @@
 import { cacheTableMap } from '$utils/dexie';
 import { get } from 'svelte/store';
-import { __fontType, __chapterData, __verseTranslationData, __wordTranslation, __wordTransliteration, __verseTranslations } from '$utils/stores';
+import { __fontType, __chapterData, __verseTranslationData, __wordTranslation, __wordTransliteration, __verseTranslations, __verseKeyData } from '$utils/stores';
 import { staticEndpoint, cdnStaticDataUrls } from '$data/websiteSettings';
 import { selectableFontTypes, selectableWordTranslations, selectableWordTransliterations, selectableVerseTranslations } from '$data/options';
 
@@ -58,7 +58,12 @@ export async function fetchChapterData(props) {
 	}
 
 	// Update store
-	if (!props.preventStoreUpdate) __chapterData.set(result);
+	if (!props.preventStoreUpdate) {
+		__chapterData.set(result);
+
+		// Verse metadata so reading progress bar can use word count
+		__verseKeyData.set(metaVerseData);
+	}
 
 	return result;
 }

--- a/src/utils/stores.js
+++ b/src/utils/stores.js
@@ -59,7 +59,8 @@ let __currentPage,
 	__verseWordBlocks,
 	__offlineModeSettings,
 	__homepageLayoutPreferences,
-	__fullVersesDisplayKeys;
+	__fullVersesDisplayKeys,
+	__verseKeyData;
 
 if (browser) {
 	const userSettings = JSON.parse(localStorage.getItem('userSettings'));
@@ -225,6 +226,9 @@ if (browser) {
 
 	// to store the keys from FullVersesDisplay component for progress tracking
 	__fullVersesDisplayKeys = writable(null);
+
+	// to store the per verse metadata (page, juz, hizb, word count) for the whole Quran
+	__verseKeyData = writable(null);
 }
 
 export {
@@ -286,5 +290,6 @@ export {
 	__verseWordBlocks,
 	__offlineModeSettings,
 	__homepageLayoutPreferences,
-	__fullVersesDisplayKeys
+	__fullVersesDisplayKeys,
+	__verseKeyData
 };

--- a/src/utils/trackReadingPosition.js
+++ b/src/utils/trackReadingPosition.js
@@ -1,0 +1,35 @@
+import { get } from 'svelte/store';
+import { __lastRead } from '$utils/stores';
+import { updateSettings } from '$utils/updateSettings';
+
+const visibleVerses = new Map();
+const versePosition = (meta) => meta.chapter * 1000 + meta.verse;
+
+// Stores the furthest verse currently on screen as the last read one.
+export function trackReadingPosition(meta, { inView, node }) {
+	if (inView) visibleVerses.set(node, meta);
+	else visibleVerses.delete(node);
+
+	let furthestVerse = null;
+
+	for (const [verseNode, verseMeta] of visibleVerses) {
+		if (!verseNode.isConnected) {
+			visibleVerses.delete(verseNode);
+			continue;
+		}
+
+		if (furthestVerse === null || versePosition(verseMeta) > versePosition(furthestVerse)) {
+			furthestVerse = verseMeta;
+		}
+	}
+
+	if (furthestVerse === null) {
+		return;
+	}
+	const lastRead = get(__lastRead);
+	if (lastRead?.chapter === furthestVerse.chapter && lastRead?.verse === furthestVerse.verse) {
+		return;
+	}
+
+	updateSettings({ type: 'lastRead', value: furthestVerse });
+}


### PR DESCRIPTION
## Problem

The reading progress bar computed progress by verse number. With the verse lengths varying the bar percentage sometimes drifted a lot from reality.

## Change

Progress is now computed by word count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading progress now updates more accurately as verses enter and leave view.
  * Progress indicators use word-based calculations for more precise chapter, Juz, and Hizb progress.
* **Bug Fixes**
  * Improved persistence of the furthest verse viewed across reading layouts.
  * Enhanced progress accuracy while verse data is still loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->