### PR TITLE
Feat/audio length delay highlight

### DIFF
--- a/src/components/ui/Modals/AudioModal.svelte
+++ b/src/components/ui/Modals/AudioModal.svelte
@@ -10,7 +10,7 @@
 	import { __currentPage, __chapterNumber, __audioSettings, __audioModalVisible, __reciter, __translationReciter, __playbackSpeed } from '$utils/stores';
 	import { prepareVersesToPlay, playButtonHandler } from '$utils/audioController';
 	import { disabledClasses, buttonClasses, selectedRadioOrCheckboxClasses } from '$data/commonClasses';
-	import { selectableAudioDelays, selectableRepeatTimes } from '$data/options';
+	import { selectableAudioDelays, selectableRepeatTimes, selectableReciters } from '$data/options';
 	import { term } from '$utils/terminologies';
 	import { getModalTransition } from '$utils/getModalTransition';
 	import { updateSettings } from '$utils/updateSettings';
@@ -26,6 +26,9 @@
 	let endVerseDropdownOpen = false;
 	let timesToRepeatDropdownOpen = false;
 	let audioDelayDropdownOpen = false;
+	// Assisted highlights only with audio length delay is silent and only wbw timings
+	$: isAudioLengthDelay = selectableAudioDelays[$__audioSettings.audioDelay]?.audioLengthSpeed !== undefined;
+	$: reciterHasWordHighlights = selectableReciters[$__reciter]?.wbw === true;
 	let startVerseSearch = ''; // Holds search input for start verse
 	let endVerseSearch = ''; // Holds search input for end verse
 	$: versesInChapter = quranMetaData[$__chapterNumber].verses;
@@ -114,7 +117,8 @@
 				language: source.language,
 				audioRange: source.audioRange,
 				timesToRepeat: source.timesToRepeat,
-				audioDelay: source.audioDelay
+				audioDelay: source.audioDelay,
+				assistedHighlightsDuringDelay: source.assistedHighlightsDuringDelay ?? defaultSettings.audioSettings.assistedHighlightsDuringDelay
 			});
 		};
 
@@ -392,6 +396,22 @@
 							{/each}
 						</Dropdown>
 					</div>
+
+					<!-- assisted highlights during an audio length delay -->
+					{#if isAudioLengthDelay}
+						<div class="flex flex-col space-y-1 w-full {!reciterHasWordHighlights && disabledClasses}">
+							<Checkbox checked={$__audioSettings.assistedHighlightsDuringDelay} disabled={!reciterHasWordHighlights} on:click={() => ($__audioSettings.assistedHighlightsDuringDelay = !$__audioSettings.assistedHighlightsDuringDelay)} class="space-x-2 font-normal bg-theme-bg">
+								<span class="text-sm">Assisted Word Highlights</span>
+							</Checkbox>
+							<span class="text-xs opacity-70">
+								{#if reciterHasWordHighlights}
+									Highlights the words at the reciter's pace during the silent delay, so you can follow along while repeating the {term('verse')}.
+								{:else}
+									Only available for reciters that support word by word highlighting.
+								{/if}
+							</span>
+						</div>
+					{/if}
 				</div>
 			</div>
 		{/if}

--- a/src/components/ui/Modals/AudioModal.svelte
+++ b/src/components/ui/Modals/AudioModal.svelte
@@ -10,7 +10,7 @@
 	import { __currentPage, __chapterNumber, __audioSettings, __audioModalVisible, __reciter, __translationReciter, __playbackSpeed } from '$utils/stores';
 	import { prepareVersesToPlay, playButtonHandler } from '$utils/audioController';
 	import { disabledClasses, buttonClasses, selectedRadioOrCheckboxClasses } from '$data/commonClasses';
-	import { selectableAudioDelays, selectableRepeatTimes, selectableReciters } from '$data/options';
+	import { selectableAudioDelays, selectableAudioDelaysOrder, selectableRepeatTimes, selectableReciters } from '$data/options';
 	import { term } from '$utils/terminologies';
 	import { getModalTransition } from '$utils/getModalTransition';
 	import { updateSettings } from '$utils/updateSettings';
@@ -26,6 +26,8 @@
 	let endVerseDropdownOpen = false;
 	let timesToRepeatDropdownOpen = false;
 	let audioDelayDropdownOpen = false;
+	// Listed in the order set by selectableAudioDelaysOrder rather than by id
+	const selectableAudioDelayOptions = selectableAudioDelaysOrder.map((id) => selectableAudioDelays[id]).filter(Boolean);
 	// Assisted highlights only with audio length delay is silent and only wbw timings
 	$: isAudioLengthDelay = selectableAudioDelays[$__audioSettings.audioDelay]?.audioLengthSpeed !== undefined;
 	$: reciterHasWordHighlights = selectableReciters[$__reciter]?.wbw === true;
@@ -69,7 +71,7 @@
 	}
 
 	// Default to no delay
-	if ($__audioSettings.audioDelay === undefined) {
+	if (selectableAudioDelays[$__audioSettings.audioDelay] === undefined) {
 		$__audioSettings.audioDelay = 1;
 	}
 
@@ -385,7 +387,7 @@
 							<div>{selectableAudioDelays[$__audioSettings.audioDelay].name}</div>
 						</button>
 						<Dropdown bind:open={audioDelayDropdownOpen} class="max-h-52 overflow-y-auto my-2 px-2">
-							{#each Object.values(selectableAudioDelays) as delay}
+							{#each selectableAudioDelayOptions as delay}
 								<DropdownItem
 									class={dropdownItemClasses}
 									on:click={() => {

--- a/src/components/ui/Modals/AudioModal.svelte
+++ b/src/components/ui/Modals/AudioModal.svelte
@@ -353,7 +353,7 @@
 
 		{#if $__audioSettings.audioType === 'verse'}
 			<div class="flex flex-col space-y-4 py-4 border-t border-theme-accent/20">
-				<div class="flex flex-row space-x-4">
+				<div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-3">
 					<!-- repeat times -->
 					<div class="flex flex-row space-x-2">
 						<span class="m-auto text-sm"> Repeat </span>

--- a/src/components/ui/Modals/AudioModal.svelte
+++ b/src/components/ui/Modals/AudioModal.svelte
@@ -31,6 +31,7 @@
 	// Assisted highlights only with audio length delay is silent and only wbw timings
 	$: isAudioLengthDelay = selectableAudioDelays[$__audioSettings.audioDelay]?.audioLengthSpeed !== undefined;
 	$: reciterHasWordHighlights = selectableReciters[$__reciter]?.wbw === true;
+	$: isArabicPlayback = $__audioSettings.language === 'arabic';
 	let startVerseSearch = ''; // Holds search input for start verse
 	let endVerseSearch = ''; // Holds search input for end verse
 	$: versesInChapter = quranMetaData[$__chapterNumber].verses;
@@ -414,7 +415,7 @@
 					</div>
 
 					<!-- assisted highlights during an audio length delay -->
-					{#if isAudioLengthDelay}
+					{#if isAudioLengthDelay && isArabicPlayback}
 						<div class="flex flex-col space-y-1 w-full {!reciterHasWordHighlights && disabledClasses}">
 							<Checkbox checked={$__audioSettings.assistedHighlightsDuringDelay} disabled={!reciterHasWordHighlights} on:click={() => toggleAssistedHighlights()} class="space-x-2 font-normal bg-theme-bg">
 								<span class="text-sm">Assisted Word Highlights</span>

--- a/src/components/ui/Modals/AudioModal.svelte
+++ b/src/components/ui/Modals/AudioModal.svelte
@@ -144,6 +144,19 @@
 		updateSettings({ type: 'audioSettings', value: audioSettings });
 	}
 
+	function trackEvent(eventName, eventData) {
+		if (window.umami && typeof window.umami.track === 'function') {
+			window.umami.track(eventName, eventData);
+		}
+	}
+
+	function toggleAssistedHighlights() {
+		const newSetting = !$__audioSettings.assistedHighlightsDuringDelay;
+
+		$__audioSettings.assistedHighlightsDuringDelay = newSetting;
+		trackEvent('Toggle Assisted Word Highlights', { enabled: newSetting });
+	}
+
 	// This function toggles the rememberSettings property within the $__audioSettings object.
 	// Depending on the new state, it calls savedPlaySettingsHandler to either save or reset the audio settings.
 	function toggleRememberSettings() {
@@ -393,6 +406,7 @@
 									on:click={() => {
 										$__audioSettings.audioDelay = delay.id;
 										audioDelayDropdownOpen = !audioDelayDropdownOpen;
+										trackEvent('Audio Delay Option', { delay: delay.name });
 									}}>{delay.name}</DropdownItem
 								>
 							{/each}
@@ -402,7 +416,7 @@
 					<!-- assisted highlights during an audio length delay -->
 					{#if isAudioLengthDelay}
 						<div class="flex flex-col space-y-1 w-full {!reciterHasWordHighlights && disabledClasses}">
-							<Checkbox checked={$__audioSettings.assistedHighlightsDuringDelay} disabled={!reciterHasWordHighlights} on:click={() => ($__audioSettings.assistedHighlightsDuringDelay = !$__audioSettings.assistedHighlightsDuringDelay)} class="space-x-2 font-normal bg-theme-bg">
+							<Checkbox checked={$__audioSettings.assistedHighlightsDuringDelay} disabled={!reciterHasWordHighlights} on:click={() => toggleAssistedHighlights()} class="space-x-2 font-normal bg-theme-bg">
 								<span class="text-sm">Assisted Word Highlights</span>
 							</Checkbox>
 							<span class="text-xs opacity-70">

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -930,10 +930,9 @@ export const selectableAudioDelays = {
 // The order the delay options are listed in
 export const selectableAudioDelaysOrder = [
 	1, // None
-	7, // Audio Length (1x)
 	8, // Audio Length (0.5x)
-	9, // Audio Length (0.75x)
-	11, // Audio Length (1.25x)
+	7, // Audio Length (1x)
+	11, // Audio Length (1.5x)
 	2, // 1 second
 	3, // 3 seconds
 	4, // 5 seconds

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -922,7 +922,10 @@ export const selectableAudioDelays = {
 	4: { id: 4, name: '5 seconds', milliseconds: 5000 },
 	5: { id: 5, name: '10 seconds', milliseconds: 10000 },
 	6: { id: 6, name: '15 seconds', milliseconds: 15000 },
-	7: { id: 7, name: 'Audio Length', milliseconds: 999 }
+	7: { id: 7, name: 'Audio Length (1x)', milliseconds: 0, audioLengthSpeed: 1 },
+	8: { id: 8, name: 'Audio Length (0.5x)', milliseconds: 0, audioLengthSpeed: 0.5 },
+	9: { id: 9, name: 'Audio Length (0.75x)', milliseconds: 0, audioLengthSpeed: 0.75 },
+	11: { id: 11, name: 'Audio Length (1.25x)', milliseconds: 0, audioLengthSpeed: 1.25 }
 };
 
 export const selectableRepeatTimes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50];

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -922,10 +922,9 @@ export const selectableAudioDelays = {
 	4: { id: 4, name: '5 seconds', milliseconds: 5000 },
 	5: { id: 5, name: '10 seconds', milliseconds: 10000 },
 	6: { id: 6, name: '15 seconds', milliseconds: 15000 },
-	7: { id: 7, name: 'Audio Length (1x)', milliseconds: 0, audioLengthSpeed: 1 },
-	8: { id: 8, name: 'Audio Length (0.5x)', milliseconds: 0, audioLengthSpeed: 0.5 },
-	9: { id: 9, name: 'Audio Length (0.75x)', milliseconds: 0, audioLengthSpeed: 0.75 },
-	11: { id: 11, name: 'Audio Length (1.25x)', milliseconds: 0, audioLengthSpeed: 1.25 }
+	7: { id: 7, name: 'Ayah Length (1x)', milliseconds: 0, audioLengthSpeed: 1 },
+	8: { id: 8, name: 'Ayah Length (0.5x)', milliseconds: 0, audioLengthSpeed: 0.5 },
+	11: { id: 11, name: 'Ayah Length (1.5x)', milliseconds: 0, audioLengthSpeed: 1.5 }
 };
 
 // The order the delay options are listed in

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -928,4 +928,18 @@ export const selectableAudioDelays = {
 	11: { id: 11, name: 'Audio Length (1.25x)', milliseconds: 0, audioLengthSpeed: 1.25 }
 };
 
+// The order the delay options are listed in
+export const selectableAudioDelaysOrder = [
+	1, // None
+	7, // Audio Length (1x)
+	8, // Audio Length (0.5x)
+	9, // Audio Length (0.75x)
+	11, // Audio Length (1.25x)
+	2, // 1 second
+	3, // 3 seconds
+	4, // 5 seconds
+	5, // 10 seconds
+	6 // 15 seconds
+];
+
 export const selectableRepeatTimes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50];

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -47,6 +47,7 @@ export const defaultSettings = {
 		timesToRepeat: 1,
 		repeatType: 'repeatVerse',
 		audioDelay: 1, // none
+		assistedHighlightsDuringDelay: true,
 		savedPlaySettings: {},
 		wbwAutoScrollEnabled: false
 	},

--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -117,6 +117,10 @@ export async function playVerseAudio(props) {
 		const audioLengthSpeed = delayOption?.audioLengthSpeed;
 		const calculatedDelay = audioLengthSpeed ? ((audio.duration || 0) * 1000) / audioLengthSpeed : delayOption?.milliseconds || 0;
 
+		// With audio length delay the verse is replayed silently
+		// words lighting up guide the reader
+		const assistedHighlightsEnabled = audioLengthSpeed && audioSettings.assistedHighlightsDuringDelay && reciter.wbw && props.language === 'arabic';
+
 		// If playing both languages, immediately follow Arabic with the translation
 		// before applying any delay or advancing to the next verse
 		if (playBoth && previousLanguage === 'arabic') {
@@ -128,7 +132,12 @@ export async function playVerseAudio(props) {
 		}
 
 		// Wait for the configured delay before moving to the next verse
-		if (calculatedDelay > 0) {
+		if (assistedHighlightsEnabled) {
+			await playAssistedHighlights(audioLengthSpeed, requestId);
+
+			// A stop or a newer request during the silent replay cancels the rest of the queue
+			if (requestId !== activeAudioRequestId) return;
+		} else if (calculatedDelay > 0) {
 			await new Promise((resolve) => setTimeout(resolve, calculatedDelay));
 		}
 
@@ -326,6 +335,52 @@ export async function wordAudioController(props) {
 	}
 
 	props.type === 'end' ? showAudioModal(`${chapter}:${verse}`) : playWordAudio({ key: props.key });
+}
+
+// Replay the verse that just finished with the audio muted
+// So word highlight plays at the delay's speed 
+async function playAssistedHighlights(speed, requestId) {
+	const originalPlaybackRate = audio.playbackRate;
+
+	try {
+		const audioSettings = get(__audioSettings);
+		audioSettings.playingWordKey = null;
+		__audioSettings.set(audioSettings);
+
+		audio.muted = true;
+		audio.currentTime = 0;
+		audio.playbackRate = speed;
+		audio.addEventListener('timeupdate', wordHighlighter);
+		await audio.play();
+
+		// Resolve on pause as well as ended, otherwise stopping mid-replay would leave
+		// this promise hanging and the player muted
+		await new Promise((resolve) => {
+			if (audio.paused || audio.ended) return resolve();
+
+			const onDone = () => {
+				audio.removeEventListener('ended', onDone);
+				audio.removeEventListener('pause', onDone);
+				resolve();
+			};
+
+			audio.addEventListener('ended', onDone);
+			audio.addEventListener('pause', onDone);
+		});
+	} catch (error) {
+		console.warn(error);
+	} finally {
+		audio.removeEventListener('timeupdate', wordHighlighter);
+		audio.muted = false;
+		audio.playbackRate = originalPlaybackRate;
+
+		// Leave no word highlighted going into the next verse
+		if (requestId === activeAudioRequestId) {
+			const settings = get(__audioSettings);
+			settings.playingWordKey = null;
+			__audioSettings.set(settings);
+		}
+	}
 }
 
 // Highlight the currently playing word during verse audio playback.

--- a/src/utils/audioController.js
+++ b/src/utils/audioController.js
@@ -112,12 +112,10 @@ export async function playVerseAudio(props) {
 		const previousLanguage = props.language;
 
 		// Calculate the delay between verses based on the user's audioDelay setting.
-		// The last delay option is a special case — it waits for the duration of the
-		// audio itself (i.e. a full extra play-length pause) rather than a fixed ms value
-		const delaySetting = audioSettings.audioDelay;
-		const delay = selectableAudioDelays[delaySetting]?.milliseconds || 0;
-		const isAudioLengthDelay = delaySetting === Math.max(...Object.keys(selectableAudioDelays).map(Number));
-		const calculatedDelay = isAudioLengthDelay ? (audio.duration || 0) * 1000 : delay;
+		// Audio length delay options wait for as long as the recitation would take at the chosen speed
+		const delayOption = selectableAudioDelays[audioSettings.audioDelay];
+		const audioLengthSpeed = delayOption?.audioLengthSpeed;
+		const calculatedDelay = audioLengthSpeed ? ((audio.duration || 0) * 1000) / audioLengthSpeed : delayOption?.milliseconds || 0;
 
 		// If playing both languages, immediately follow Arabic with the translation
 		// before applying any delay or advancing to the next verse


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added audio-length delay options at 0.5×, 1×, and 1.5× playback speeds.
  * Added optional assisted word highlights during audio-length delays for supported reciters.
  * Added configurable ordering for audio delay options.
  * Assisted highlights are enabled by default and saved between sessions.

* **Bug Fixes**
  * Improved validation for unavailable audio-delay settings.
  * Ensured playback state and controls are restored correctly after assisted highlighting.

* **Style**
  * Repeat controls now wrap responsively on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->