### PR TITLE
feat: add colored bookmarks with 8 aesthetic tints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,13 @@
 				"svelte-portal": "^2.2.1"
 			},
 			"devDependencies": {
+				"@playwright/test": "1.47",
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/adapter-node": "^5.4.0",
 				"@sveltejs/kit": "^2.26.1",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"@types/eslint": "^8.56.0",
+				"@vitest/coverage-v8": "1.6",
 				"autoprefixer": "^10.4.19",
 				"eslint": "^8.57.1",
 				"eslint-config-prettier": "^9.1.0",
@@ -29,12 +31,14 @@
 				"eslint-plugin-unused-imports": "^4.1.4",
 				"flowbite": "^2.3.0",
 				"flowbite-svelte": "^0.46.1",
+				"jsdom": "^24.1.3",
 				"postcss": "^8.4.38",
 				"prettier": "^3.1.1",
 				"svelte": "^4.2.19",
 				"tailwind-scrollbar": "^3.1.0",
 				"tailwindcss": "^3.4.1",
-				"vite": "^5.4.15"
+				"vite": "^5.4.15",
+				"vitest": "1.6"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -58,6 +62,181 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"dev": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.29.8"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -607,6 +786,27 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"dev": true,
@@ -668,6 +868,21 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+			"integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+			"dev": true,
+			"dependencies": {
+				"playwright": "1.47.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1136,6 +1351,12 @@
 				"win32"
 			]
 		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.27.12",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+			"integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+			"dev": true
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"dev": true,
@@ -1324,6 +1545,138 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+			"integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+			"dev": true,
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
+				"@bcoe/v8-coverage": "^0.2.3",
+				"debug": "^4.3.4",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-lib-source-maps": "^5.0.4",
+				"istanbul-reports": "^3.1.6",
+				"magic-string": "^0.30.5",
+				"magicast": "^0.3.3",
+				"picocolors": "^1.0.0",
+				"std-env": "^3.5.0",
+				"strip-literal": "^2.0.0",
+				"test-exclude": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"vitest": "1.6.1"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+			"integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/spy": "1.6.1",
+				"@vitest/utils": "1.6.1",
+				"chai": "^4.3.10"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+			"integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/utils": "1.6.1",
+				"p-limit": "^5.0.0",
+				"pathe": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/p-limit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+			"integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vitest/runner/node_modules/yocto-queue": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+			"integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+			"integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+			"dev": true,
+			"dependencies": {
+				"magic-string": "^0.30.5",
+				"pathe": "^1.1.1",
+				"pretty-format": "^29.7.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+			"integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+			"dev": true,
+			"dependencies": {
+				"tinyspy": "^2.2.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+			"integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+			"dev": true,
+			"dependencies": {
+				"diff-sequences": "^29.6.3",
+				"estree-walker": "^3.0.3",
+				"loupe": "^2.3.7",
+				"pretty-format": "^29.7.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/@yr/monotone-cubic-spline": {
 			"version": "1.0.3",
 			"dev": true,
@@ -1347,6 +1700,27 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/ajv": {
@@ -1449,6 +1823,21 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.24",
 			"dev": true,
@@ -1498,11 +1887,15 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.19",
+			"version": "2.11.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+			"integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -1569,6 +1962,28 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"dev": true,
@@ -1586,7 +2001,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001769",
+			"version": "1.0.30001810",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+			"integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1601,8 +2018,25 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"license": "CC-BY-4.0"
+			]
+		},
+		"node_modules/chai": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+			"integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+			"dev": true,
+			"dependencies": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1617,6 +2051,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/chokidar": {
@@ -1689,6 +2135,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "4.1.1",
 			"dev": true,
@@ -1708,6 +2166,12 @@
 			"version": "0.0.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true
 		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
@@ -1752,6 +2216,38 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"dev": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/cssstyle/node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"dev": true,
@@ -1768,6 +2264,24 @@
 				}
 			}
 		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true
+		},
+		"node_modules/deep-eql": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+			"integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+			"dev": true,
+			"dependencies": {
+				"type-detect": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"dev": true,
@@ -1779,6 +2293,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/devalue": {
@@ -1795,6 +2318,15 @@
 			"version": "1.2.2",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/diff-sequences": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
@@ -1822,10 +2354,81 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.286",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.12",
@@ -2123,6 +2726,29 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"dev": true,
@@ -2281,6 +2907,22 @@
 				"svelte": "^3.55.1 || ^4.0.0 || ^5.0.0"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fraction.js": {
 			"version": "5.3.4",
 			"dev": true,
@@ -2319,6 +2961,64 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-func-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -2365,6 +3065,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"dev": true,
@@ -2378,15 +3090,108 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
-			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -2508,6 +3313,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"dev": true,
@@ -2516,10 +3327,72 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/jiti": {
 			"version": "1.21.7",
@@ -2528,6 +3401,12 @@
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.3.1",
@@ -2549,6 +3428,46 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "24.1.3",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+			"integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+			"dev": true,
+			"dependencies": {
+				"cssstyle": "^4.0.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.4.3",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.12",
+				"parse5": "^7.1.2",
+				"rrweb-cssom": "^0.7.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.4",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^2.11.2"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -2612,6 +3531,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/local-pkg": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+			"integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+			"dev": true,
+			"dependencies": {
+				"mlly": "^1.7.3",
+				"pkg-types": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"dev": true,
@@ -2636,12 +3571,53 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/loupe": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.1"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+			"integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/parser": "^7.25.4",
+				"@babel/types": "^7.25.4",
+				"source-map-js": "^1.2.0"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/marked": {
@@ -2654,10 +3630,25 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -2691,6 +3682,39 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/mini-svg-data-uri": {
 			"version": "1.4.4",
 			"dev": true,
@@ -2711,6 +3735,24 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+			"integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.3"
+			}
+		},
+		"node_modules/mlly/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true
 		},
 		"node_modules/mrmime": {
 			"version": "2.0.1",
@@ -2771,6 +3813,39 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.24",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+			"integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+			"dev": true
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"dev": true,
@@ -2793,6 +3868,21 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
@@ -2850,6 +3940,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"dev": true,
@@ -2878,6 +3980,21 @@
 			"version": "1.0.7",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true
+		},
+		"node_modules/pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/periscopic": {
 			"version": "3.1.0",
@@ -2928,6 +4045,67 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/pkg-types/node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true
+		},
+		"node_modules/playwright": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+			"integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.47.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.47.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+			"integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -3140,6 +4318,44 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"dev": true,
@@ -3147,6 +4363,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -3166,6 +4388,12 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
 		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
@@ -3197,6 +4425,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.11",
@@ -3293,6 +4527,12 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+			"dev": true
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"dev": true,
@@ -3313,6 +4553,24 @@
 			"license": "MIT",
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/semver": {
@@ -3350,6 +4608,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"dev": true,
@@ -3371,6 +4647,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"dev": true,
@@ -3382,6 +4670,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"dev": true,
@@ -3391,6 +4691,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/strip-literal": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+			"integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+			"dev": true,
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/sucrase": {
@@ -3599,6 +4911,12 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
+		},
 		"node_modules/tailwind-merge": {
 			"version": "2.6.1",
 			"dev": true,
@@ -3719,6 +5037,20 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"dev": true,
@@ -3743,6 +5075,12 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"dev": true,
@@ -3756,6 +5094,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+			"integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+			"integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -3777,6 +5133,33 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"dev": true,
@@ -3793,6 +5176,15 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/type-detect": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/type-fest": {
 			"version": "0.20.2",
 			"dev": true,
@@ -3802,6 +5194,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ufo": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+			"integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+			"dev": true
+		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -3839,6 +5246,16 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -3903,6 +5320,28 @@
 				}
 			}
 		},
+		"node_modules/vite-node": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+			"integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+			"dev": true,
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.3.4",
+				"pathe": "^1.1.1",
+				"picocolors": "^1.0.0",
+				"vite": "^5.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/vitefu": {
 			"version": "0.2.5",
 			"dev": true,
@@ -3914,6 +5353,127 @@
 				"vite": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+			"integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+			"dev": true,
+			"dependencies": {
+				"@vitest/expect": "1.6.1",
+				"@vitest/runner": "1.6.1",
+				"@vitest/snapshot": "1.6.1",
+				"@vitest/spy": "1.6.1",
+				"@vitest/utils": "1.6.1",
+				"acorn-walk": "^8.3.2",
+				"chai": "^4.3.10",
+				"debug": "^4.3.4",
+				"execa": "^8.0.1",
+				"local-pkg": "^0.5.0",
+				"magic-string": "^0.30.5",
+				"pathe": "^1.1.1",
+				"picocolors": "^1.0.0",
+				"std-env": "^3.5.0",
+				"strip-literal": "^2.0.0",
+				"tinybench": "^2.5.1",
+				"tinypool": "^0.8.3",
+				"vite": "^5.0.0",
+				"vite-node": "1.6.1",
+				"why-is-node-running": "^2.2.2"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"@vitest/browser": "1.6.1",
+				"@vitest/ui": "1.6.1",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"dev": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/which": {
@@ -3930,6 +5490,22 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"dev": true,
@@ -3942,6 +5518,42 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
 		},
 		"node_modules/yaml": {
 			"version": "1.10.3",

--- a/src/components/display/ColoredBookmarkCard.svelte
+++ b/src/components/display/ColoredBookmarkCard.svelte
@@ -1,0 +1,129 @@
+<script>
+	export let bookmark;
+	export let fullQuranTextData = null;
+	export let cardInnerClasses;
+	export let forceClose = 0;
+	export let colorId;
+
+	import Portal from 'svelte-portal';
+	import Dropdown from '$ui/FlowbiteSvelte/dropdown/Dropdown.svelte';
+	import DropdownItem from '$ui/FlowbiteSvelte/dropdown/DropdownItem.svelte';
+	import DotsHorizontal from '$svgs/DotsHorizontal.svelte';
+	import Trash from '$svgs/Trash.svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { quranMetaData } from '$data/quranMeta';
+	import { updateSettings } from '$utils/updateSettings';
+	import { showConfirm } from '$utils/confirmationAlertHandler';
+	import { COLOR_TOKENS, isDarkTheme } from '$utils/coloredBookmarks';
+	import { __websiteTheme } from '$utils/stores';
+
+	const dispatch = createEventDispatcher();
+	const dropdownItemClasses = 'flex flex-row items-center space-x-2 font-normal rounded-3xl hover:bg-theme-accent/5';
+	const [bookmarkChapter, bookmarkVerse] = bookmark.split(':').map(Number);
+	const chapterMeta = quranMetaData[bookmarkChapter];
+	const maxTextLength = 'max-w-[28vw] md:max-w-[115px]';
+
+	let dropdownOpen = false;
+	let buttonElement;
+	let hasMounted = false;
+	let previousOpen = dropdownOpen;
+	let previousForceClose = forceClose;
+
+	$: isDark = isDarkTheme($__websiteTheme);
+	$: token = COLOR_TOKENS[colorId];
+	$: accentHex = token ? (isDark ? token.darkHex : token.lightHex) : 'transparent';
+
+	// Watch forceClose to close dropdown when parent scrolls
+	onMount(() => {
+		hasMounted = true;
+		previousOpen = dropdownOpen;
+	});
+
+	$: if (hasMounted && dropdownOpen !== previousOpen) {
+		previousOpen = dropdownOpen;
+		dispatch('toggle', { bookmark, open: dropdownOpen });
+	}
+
+	$: if (forceClose !== previousForceClose) {
+		previousForceClose = forceClose;
+		if (dropdownOpen) {
+			dropdownOpen = false;
+			buttonElement?.blur();
+		}
+	}
+
+	function toggleDropdown() {
+		dropdownOpen = !dropdownOpen;
+	}
+
+	function handleClearColor(event) {
+		event.stopPropagation();
+		const name = token?.name ?? `color ${colorId}`;
+		showConfirm(`Remove ${name} color from ${bookmark}?`, null, () => {
+			updateSettings({ type: 'userColoredBookmarks', key: bookmark, clear: true });
+			window.umami?.track('Clear Colored Bookmark Card', { verseKey: bookmark, colorId });
+		});
+	}
+</script>
+
+<div
+	class="relative bookmark-menu-container {cardInnerClasses} !p-0 overflow-visible {dropdownOpen ? '!border-transparent' : ''}"
+	role="article"
+	aria-label="Colored bookmark for {chapterMeta.transliteration} verse {bookmarkVerse} in {token?.name ?? ''}"
+	style="border-left-width: 4px; border-left-color: {accentHex}; border-left-style: solid;"
+>
+	<a
+		href="/{bookmarkChapter}?startVerse={bookmarkVerse}"
+		class="!justify-start flex flex-col w-full p-5 {dropdownOpen ? 'pointer-events-none' : ''}"
+		aria-label="Go to {chapterMeta.transliteration} verse {bookmarkVerse}"
+	>
+		<div class="text-sm truncate {maxTextLength} flex items-center gap-2">
+			<span>{chapterMeta.transliteration} ({bookmark})</span>
+			<span class="w-2.5 h-2.5 rounded-full border border-theme-accent/20 inline-block" style="background-color: {accentHex}" aria-hidden="true"></span>
+		</div>
+
+		{#if fullQuranTextData}
+			<div class="text-sm truncate text-right direction-rtl arabic-font-1 opacity-70 mt-2">
+				{#await fullQuranTextData then data}
+					{@const verseText = data.data[`${bookmarkChapter}:${bookmarkVerse}`]}
+					<div class="truncate {maxTextLength}" lang="ar">
+						{verseText}
+					</div>
+				{:catch _error}
+					<span class="text-xs opacity-50" role="alert">Failed to load verse</span>
+				{/await}
+			</div>
+		{/if}
+	</a>
+
+	<!-- Options menu button -->
+	<button
+		id="colored-bookmark-menu-{bookmark.replace(':', '-')}-{colorId}"
+		bind:this={buttonElement}
+		on:click|stopPropagation={toggleDropdown}
+		on:touchend|preventDefault|stopPropagation={toggleDropdown}
+		class="absolute top-2 right-2 p-1 rounded-full hover:bg-theme-accent/5 opacity-70 hover:opacity-100 transition-opacity z-10 focus:outline-none"
+		aria-label={dropdownOpen ? 'Close menu' : 'Open options menu'}
+		aria-expanded={dropdownOpen}
+		aria-haspopup="true"
+	>
+		<DotsHorizontal size={5} />
+	</button>
+</div>
+
+{#if buttonElement}
+	<Portal target="body">
+		<Dropdown
+			bind:open={dropdownOpen}
+			triggeredBy="#colored-bookmark-menu-{bookmark.replace(':', '-')}-{colorId}"
+			strategy="fixed"
+			containerClass={`divide-y z-[1000] shadow-md border border-theme-accent/20`}
+			class="px-2 my-2 w-max text-left font-sans direction-ltr"
+		>
+			<DropdownItem class={dropdownItemClasses} on:click={handleClearColor}>
+				<Trash size={4} aria-hidden="true" />
+				<span>Clear color</span>
+			</DropdownItem>
+		</Dropdown>
+	</Portal>
+{/if}

--- a/src/components/display/UserColoredBookmarks.svelte
+++ b/src/components/display/UserColoredBookmarks.svelte
@@ -1,0 +1,177 @@
+<script>
+	import ColoredBookmarkCard from '$display/ColoredBookmarkCard.svelte';
+	import ScrollableFadeContainer from '$display/ScrollableFadeContainer.svelte';
+	import { __userColoredBookmarks, __websiteTheme } from '$utils/stores';
+	import { cdnStaticDataUrls } from '$data/websiteSettings';
+	import { fetchAndCacheJson } from '$utils/fetchData';
+	import { term } from '$utils/terminologies';
+	import { COLOR_TOKENS, isDarkTheme } from '$utils/coloredBookmarks';
+	import { isValidVerseKey } from '$utils/validateKey';
+	import { onMount } from 'svelte';
+
+	export let cardGridClasses;
+	export let cardInnerClasses;
+
+	let fullQuranTextData = null;
+	let forceCloseDropdowns = 0;
+
+	$: isDark = isDarkTheme($__websiteTheme);
+
+	// Derived grouping — reactive on $__userColoredBookmarks
+	$: coloredMap = $__userColoredBookmarks ?? {};
+	$: {
+		// trigger fetch when there is at least one colored bookmark
+		const hasAny = Object.keys(coloredMap).length > 0;
+		if (hasAny && !fullQuranTextData) loadQuranData();
+	}
+
+	$: byColor = (() => {
+		const result = { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [], 7: [], 8: [] };
+		for (const [k, v] of Object.entries(coloredMap)) {
+			const n = Number(v);
+			if (!isValidVerseKey(k)) continue;
+			if (!(n >= 1 && n <= 8)) continue;
+			result[n].push(k);
+		}
+		const cmp = (a, b) => {
+			const [ca, va] = a.split(':').map(Number);
+			const [cb, vb] = b.split(':').map(Number);
+			if (ca !== cb) return ca - cb;
+			return va - vb;
+		};
+		for (let i = 1; i <= 8; i++) result[i].sort(cmp);
+		return result;
+	})();
+
+	$: totalColored = Object.keys(coloredMap).filter((k) => {
+		const v = Number(coloredMap[k]);
+		return isValidVerseKey(k) && v >= 1 && v <= 8;
+	}).length;
+
+	$: isEmpty = totalColored === 0;
+
+	async function loadQuranData() {
+		try {
+			fullQuranTextData = await fetchAndCacheJson(cdnStaticDataUrls.fullQuranUthmani, 'other');
+		} catch (error) {
+			console.warn(error);
+		}
+	}
+
+	function handleScroll() {
+		forceCloseDropdowns += 1;
+	}
+
+	const orderedIds = [1, 2, 3, 4, 5, 6, 7, 8];
+
+	// Accordion expanded state — persisted locally, default collapsed for all
+	const STORAGE_KEY = 'coloredBookmarksAccordionExpanded';
+	function loadExpanded() {
+		try {
+			if (typeof localStorage === 'undefined') return {};
+			const raw = localStorage.getItem(STORAGE_KEY);
+			if (!raw) return {};
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+		} catch (e) {
+			void e;
+		}
+		return {};
+	}
+	function saveExpanded(map) {
+		try {
+			if (typeof localStorage === 'undefined') return;
+			localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+		} catch (e) {
+			void e;
+		}
+	}
+
+	let expanded = loadExpanded();
+
+	// Ensure expanded keys are booleans 1..8
+	$: isExpanded = (id) => !!expanded[id];
+
+	function toggleExpanded(id) {
+		const next = { ...expanded, [id]: !expanded[id] };
+		expanded = next;
+		saveExpanded(next);
+	}
+
+	function handleHeaderKeydown(event, id) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			toggleExpanded(id);
+		}
+	}
+
+	// Initialize defaults if no saved state: default collapsed for all (verses hidden until expanded)
+	// We keep collapsed even for colors with entries to satisfy "hidden until expanded".
+	// If user has never interacted, expanded stays {} (all false). No auto-expand.
+	onMount(() => {
+		// re-load in case SSR had empty and client has stored value
+		const stored = loadExpanded();
+		if (Object.keys(stored).length > 0) expanded = stored;
+	});
+</script>
+
+<ScrollableFadeContainer containerId="colored-bookmark-cards" onScrollAction={handleScroll}>
+	{#if isEmpty}
+		<div class="flex flex-col justify-start text-xs md:text-sm opacity-70 px-2 space-y-2 mb-2" role="status" aria-live="polite">
+			<span class="leading-relaxed">
+				No colored bookmarks yet. Open a {term('verse')}’s ⋮ menu → <span class="font-semibold">Colored Bookmark</span> to tint {term('verses')} for study.
+			</span>
+		</div>
+	{/if}
+	<div class="flex flex-col space-y-2">
+		{#each orderedIds as id}
+			{@const token = COLOR_TOKENS[id]}
+			{@const verses = byColor[id]}
+			{@const count = verses.length}
+			{@const accentHex = isDark ? token.darkHex : token.lightHex}
+			<section aria-labelledby="colored-section-{id}" class="border-b border-theme-accent/10 last:border-b-0">
+				<h3 class="m-0">
+					<button
+						id="colored-section-{id}"
+						type="button"
+						class="flex w-full items-center gap-2 py-2.5 px-1 text-left sticky top-0 bg-theme-bg/90 backdrop-blur z-[1] hover:bg-theme-accent/5 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-accent focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg"
+						aria-expanded={isExpanded(id)}
+						aria-controls="colored-panel-{id}"
+						on:click={() => toggleExpanded(id)}
+						on:keydown={(e) => handleHeaderKeydown(e, id)}
+					>
+						<span class="w-3 h-3 rounded-full border border-theme-accent/20 shrink-0" style="background-color: {accentHex}" aria-hidden="true"></span>
+						<span class="text-xs font-semibold flex-1">{token.name}</span>
+						<span class="text-xs opacity-60">({count})</span>
+						<svg
+							class="w-4 h-4 opacity-60 transition-transform duration-200 shrink-0 {isExpanded(id) ? 'rotate-180' : ''}"
+							aria-hidden="true"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+						</svg>
+					</button>
+				</h3>
+
+				<div
+					id="colored-panel-{id}"
+					role="region"
+					aria-labelledby="colored-section-{id}"
+					class="{isExpanded(id) ? 'block' : 'hidden'} mt-1 pb-2"
+				>
+					{#if count === 0}
+						<div class="text-xs opacity-50 px-1 py-1 opacity-40">No verses in {token.name}</div>
+					{:else}
+						<div class="{cardGridClasses} grid-cols-2 md:!grid-cols-4 mt-1">
+							{#each verses as bookmark (bookmark)}
+								<ColoredBookmarkCard {bookmark} {fullQuranTextData} {cardInnerClasses} forceClose={forceCloseDropdowns} colorId={id} />
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</section>
+		{/each}
+	</div>
+</ScrollableFadeContainer>

--- a/src/components/display/layouts/Continuous.svelte
+++ b/src/components/display/layouts/Continuous.svelte
@@ -5,13 +5,36 @@
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import { updateSettings } from '$utils/updateSettings';
 	import { inview } from 'svelte-inview';
+	import { __userColoredBookmarks, __websiteTheme } from '$utils/stores';
+	import { getVerseTintStyle } from '$utils/coloredBookmarks';
+
+	$: colorId = (() => {
+		try {
+			const v = ($__userColoredBookmarks ?? {})[key];
+			const n = Number(v);
+			return n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: tintStyle = getVerseTintStyle(colorId, $__websiteTheme);
 </script>
 
 {#if value}
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse inline py-2 group verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div
+		id={key}
+		class="verse inline py-2 group verse-{value.meta.chapter}-{value.meta.verse} rounded-lg px-1.5 py-1 box-decoration-clone transition-colors duration-200"
+		style={tintStyle || undefined}
+		data-words={value.meta.words}
+		data-page={value.meta.page}
+		data-juz={value.meta.juz}
+		data-hizb={value.meta.hizb}
+		use:inview
+		on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}
+	>
 		<WordsBlock {key} {value} />
 	</div>
 {/if}

--- a/src/components/display/layouts/Normal.svelte
+++ b/src/components/display/layouts/Normal.svelte
@@ -8,13 +8,36 @@
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
 	import { updateSettings } from '$utils/updateSettings';
 	import { inview } from 'svelte-inview';
+	import { __userColoredBookmarks, __websiteTheme } from '$utils/stores';
+	import { getVerseTintStyle } from '$utils/coloredBookmarks';
+
+	$: colorId = (() => {
+		try {
+			const v = ($__userColoredBookmarks ?? {})[key];
+			const n = Number(v);
+			return n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: tintStyle = getVerseTintStyle(colorId, $__websiteTheme);
 </script>
 
 {#if value}
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div
+		id={key}
+		class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse} rounded-xl transition-colors duration-200"
+		style={tintStyle || undefined}
+		data-words={value.meta.words}
+		data-page={value.meta.page}
+		data-juz={value.meta.juz}
+		data-hizb={value.meta.hizb}
+		use:inview
+		on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}
+	>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/display/layouts/SideBySide.svelte
+++ b/src/components/display/layouts/SideBySide.svelte
@@ -7,18 +7,40 @@
 	import PageDivider from '$display/verses/PageDivider.svelte';
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
 	import { updateSettings } from '$utils/updateSettings';
-	import { __verseTranslations } from '$utils/stores';
+	import { __verseTranslations, __userColoredBookmarks, __websiteTheme } from '$utils/stores';
 	import { inview } from 'svelte-inview';
+	import { getVerseTintStyle } from '$utils/coloredBookmarks';
 
 	// Use two columns when translations are available, otherwise fall back to one
 	$: gridCols = $__verseTranslations.length > 0 ? 'grid-cols-2' : 'grid-cols-1';
+
+	$: colorId = (() => {
+		try {
+			const v = ($__userColoredBookmarks ?? {})[key];
+			const n = Number(v);
+			return n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: tintStyle = getVerseTintStyle(colorId, $__websiteTheme);
 </script>
 
 {#if value}
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div
+		id={key}
+		class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse} rounded-xl transition-colors duration-200"
+		style={tintStyle || undefined}
+		data-words={value.meta.words}
+		data-page={value.meta.page}
+		data-juz={value.meta.juz}
+		data-hizb={value.meta.hizb}
+		use:inview
+		on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}
+	>
 		<VerseOptionButtons {key} {value} />
 
 		<div class="grid {gridCols} gap-x-8">

--- a/src/components/display/layouts/TranslationTransliteration.svelte
+++ b/src/components/display/layouts/TranslationTransliteration.svelte
@@ -8,13 +8,36 @@
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
 	import { updateSettings } from '$utils/updateSettings';
 	import { inview } from 'svelte-inview';
+	import { __userColoredBookmarks, __websiteTheme } from '$utils/stores';
+	import { getVerseTintStyle } from '$utils/coloredBookmarks';
+
+	$: colorId = (() => {
+		try {
+			const v = ($__userColoredBookmarks ?? {})[key];
+			const n = Number(v);
+			return n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: tintStyle = getVerseTintStyle(colorId, $__websiteTheme);
 </script>
 
 {#if value}
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div
+		id={key}
+		class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse} rounded-xl transition-colors duration-200"
+		style={tintStyle || undefined}
+		data-words={value.meta.words}
+		data-page={value.meta.page}
+		data-juz={value.meta.juz}
+		data-hizb={value.meta.hizb}
+		use:inview
+		on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}
+	>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/display/layouts/WordByWord.svelte
+++ b/src/components/display/layouts/WordByWord.svelte
@@ -8,13 +8,36 @@
 	import VerseSeparator from '$display/verses/VerseSeparator.svelte';
 	import { updateSettings } from '$utils/updateSettings';
 	import { inview } from 'svelte-inview';
+	import { __userColoredBookmarks, __websiteTheme } from '$utils/stores';
+	import { getVerseTintStyle } from '$utils/coloredBookmarks';
+
+	$: colorId = (() => {
+		try {
+			const v = ($__userColoredBookmarks ?? {})[key];
+			const n = Number(v);
+			return n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: tintStyle = getVerseTintStyle(colorId, $__websiteTheme);
 </script>
 
 {#if value}
 	<!-- show page/juz/hizb number  -->
 	<PageDivider {key} />
 
-	<div id={key} class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse}" data-words={value.meta.words} data-page={value.meta.page} data-juz={value.meta.juz} data-hizb={value.meta.hizb} use:inview on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}>
+	<div
+		id={key}
+		class="verse flex flex-col py-8 space-y-8 verse-{value.meta.chapter}-{value.meta.verse} rounded-xl transition-colors duration-200"
+		style={tintStyle || undefined}
+		data-words={value.meta.words}
+		data-page={value.meta.page}
+		data-juz={value.meta.juz}
+		data-hizb={value.meta.hizb}
+		use:inview
+		on:inview_enter={() => updateSettings({ type: 'lastRead', value: value.meta })}
+	>
 		<VerseOptionButtons {key} {value} />
 
 		<!-- words -->

--- a/src/components/display/verses/VerseOptionsDropdown.svelte
+++ b/src/components/display/verses/VerseOptionsDropdown.svelte
@@ -14,14 +14,16 @@
 	import Book from '$svgs/Book.svelte';
 	import Morphology from '$svgs/Morphology.svelte';
 	import Copy from '$svgs/Copy.svelte';
+	import Trash from '$svgs/Trash.svelte';
 	import { showAudioModal } from '$utils/audioController';
 	import { selectableDisplays } from '$data/options';
-	import { __userSettings, __verseKey, __notesModalVisible, __tafsirModalVisible, __morphologyModalVisible, __verseTranslationModalVisible, __copyShareVerseModalVisible, __currentPage, __displayType, __userNotes, __fontType, __morphologyKey } from '$utils/stores';
+	import { __userSettings, __verseKey, __notesModalVisible, __tafsirModalVisible, __morphologyModalVisible, __verseTranslationModalVisible, __copyShareVerseModalVisible, __currentPage, __displayType, __userNotes, __fontType, __morphologyKey, __userColoredBookmarks, __websiteTheme } from '$utils/stores';
 	import { updateSettings } from '$utils/updateSettings';
 	import { term } from '$utils/terminologies';
 	import { sineIn } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
 	import { checkOnlineAndAlert } from '$utils/offlineModeHandler';
+	import { COLOR_TOKENS, isDarkTheme } from '$utils/coloredBookmarks';
 
 	// Constants
 	const mushafFontTypes = [2, 3];
@@ -30,12 +32,35 @@
 	// Component state
 	let dropdownOpen = false;
 	let subMenuVisible = false;
+	let storageError = '';
 
 	// Computed values
 	$: [chapter, verse] = $__verseKey.split(':').map(Number);
 	$: userBookmarks = JSON.parse($__userSettings).userBookmarks;
 	$: isBookmarked = userBookmarks.includes($__verseKey);
 	$: hasNotes = Object.prototype.hasOwnProperty.call($__userNotes, $__verseKey);
+	$: currentColorId = (() => {
+		try {
+			const map = $__userColoredBookmarks ?? {};
+			const v = map[$__verseKey];
+			const n = Number(v);
+			return Number.isInteger(n) && n >= 1 && n <= 8 ? n : null;
+		} catch {
+			return null;
+		}
+	})();
+	$: currentColorToken = currentColorId ? COLOR_TOKENS[currentColorId] : null;
+	$: currentColorName = currentColorToken ? currentColorToken.name : null;
+	$: isDark = isDarkTheme($__websiteTheme);
+
+	function focusTrigger() {
+		try {
+			const el = document.getElementById(`verse-options-${verse}`);
+			el?.focus();
+		} catch (_e) {
+			// ignore focus error
+		}
+	}
 
 	// Event handlers
 	const handleAdvancedPlay = async () => {
@@ -75,12 +100,113 @@
 		dropdownOpen = false;
 	};
 
+	const openColoredSubmenu = (event) => {
+		event?.preventDefault?.();
+		event?.stopPropagation?.();
+		storageError = '';
+		subMenuVisible = true;
+		dropdownOpen = true;
+		// Keep focus inside Popper floatingEl so activeContent hideHandler (100ms hasFocus check) does not close.
+		// The clicked row is removed from DOM when submenu appears, so activeElement would become body without this.
+		setTimeout(() => {
+			try {
+				const el = document.querySelector('[aria-label="Bookmark colors"]');
+				if (el instanceof HTMLElement) el.focus();
+				else {
+					const first = document.querySelector('[role="menuitemradio"]');
+					if (first instanceof HTMLElement) first.focus();
+				}
+			} catch (_e) {
+				// ignore focus error
+			}
+		}, 0);
+	};
+
+	const closeSubMenu = (event) => {
+		event?.preventDefault?.();
+		event?.stopPropagation?.();
+		subMenuVisible = false;
+		storageError = '';
+		dropdownOpen = true;
+		// Return focus inside dropdown so hideHandler does not close; next submenu open will be via Colored Bookmark row.
+		setTimeout(() => {
+			try {
+				const btn = document.querySelector('[aria-label*="Colored Bookmark"]');
+				if (btn instanceof HTMLElement) btn.focus();
+			} catch (_e) {
+				// ignore focus error
+			}
+		}, 0);
+	};
+
+	const handleSelectColor = (colorId) => {
+		storageError = '';
+		const verseKey = $__verseKey;
+		// idempotent no-op
+		if (currentColorId === colorId) {
+			dropdownOpen = false;
+			subMenuVisible = false;
+			setTimeout(() => {
+				focusTrigger();
+				// Popper's trigger focusin would reopen dropdown (open=true on focusin); ensure it stays closed
+				setTimeout(() => (dropdownOpen = false), 0);
+			}, 0);
+			return;
+		}
+		const res = updateSettings({ type: 'userColoredBookmarks', key: verseKey, colorId });
+		if (res && !res.ok) {
+			if (res.status === 507 || res.status === 400 || res.status === 500) {
+				storageError = res.error?.message ?? 'Couldn’t save';
+				return;
+			}
+		}
+		dropdownOpen = false;
+		subMenuVisible = false;
+		// success announced via tint; polite live not needed visual
+		// Focus trigger for a11y but suppress Popper focusin reopen (focusin sets open=true)
+		setTimeout(() => {
+			focusTrigger();
+			setTimeout(() => (dropdownOpen = false), 0);
+		}, 0);
+	};
+
+	const handleClearColor = () => {
+		if (!currentColorId) return;
+		storageError = '';
+		const verseKey = $__verseKey;
+		const res = updateSettings({ type: 'userColoredBookmarks', key: verseKey, clear: true });
+		if (res && !res.ok) {
+			storageError = res.error?.message ?? 'Couldn’t save';
+			return;
+		}
+		dropdownOpen = false;
+		subMenuVisible = false;
+		setTimeout(() => {
+			focusTrigger();
+			setTimeout(() => (dropdownOpen = false), 0);
+		}, 0);
+	};
+
+	const handleSubmenuKeydown = (e) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			closeSubMenu(e);
+		}
+	};
+
 	// Track analytics
 	const trackEvent = (eventName) => {
 		window.umami.track(eventName);
 	};
 
-	// Menu items configuration
+	// Reset submenu when dropdown closes
+	$: if (!dropdownOpen) {
+		subMenuVisible = false;
+		storageError = '';
+	}
+
+	// Menu items configuration (without colored — colored rendered as dedicated row beneath play)
 	$: menuItems = [
 		{
 			id: 'play',
@@ -159,9 +285,12 @@
 						analyticsEvent: 'Mushaf Mode Button'
 					}
 				];
+
+	// For roving tabindex grid, computed ordered ids 1..8
+	const colorIds = [1, 2, 3, 4, 5, 6, 7, 8];
 </script>
 
-<Dropdown bind:open={dropdownOpen} class="px-2 mr-2 my-2 w-max text-left font-sans direction-ltr">
+<Dropdown bind:open={dropdownOpen} activeContent class="px-2 mr-2 my-2 w-max text-left font-sans direction-ltr">
 	<div class="py-2 px-4 text-xs font-semibold text-left">
 		{term('verse')}
 		{$__verseKey}
@@ -169,9 +298,42 @@
 
 	{#if !subMenuVisible}
 		<div transition:fly={{ duration: 0, x: 0, easing: sineIn }}>
-			<!-- Main menu items -->
+			<!-- Play row -->
 			{#each menuItems as item (item.id)}
-				{#if item.show}
+				{#if item.id === 'play' && item.show}
+					<DropdownItem class={dropdownItemClasses} on:click={item.handler} data-umami-event={item.analyticsEvent}>
+						<svelte:component this={item.icon} />
+						<span>{item.text}</span>
+					</DropdownItem>
+					<!-- Colored Bookmark row inserted immediately beneath Advanced Play -->
+					<button
+						class="{dropdownItemClasses} w-full text-left px-4 py-2 flex flex-row items-center justify-between"
+						on:click|stopPropagation|preventDefault={openColoredSubmenu}
+						role="menuitem"
+						aria-haspopup="menu"
+						aria-expanded="false"
+						aria-label={currentColorName ? `Colored Bookmark, Current: ${currentColorName}` : 'Colored Bookmark'}
+						data-umami-event="Colored Bookmark Menu"
+					>
+						<span class="flex flex-row items-center space-x-2">
+							<!-- palette icon (simple dot grid) -->
+							<span class="w-4 h-4 rounded-full grid grid-cols-2 gap-[1px] p-0.5 border border-theme-accent/20 overflow-hidden" aria-hidden="true">
+								<span class="bg-[#EADDB8] rounded-[1px]"></span><span class="bg-[#B9973F] rounded-[1px]"></span><span class="bg-[#DDD4E8] rounded-[1px]"></span><span class="bg-[#8FA67A] rounded-[1px]"></span>
+							</span>
+							<span>Colored Bookmark</span>
+						</span>
+						<span class="flex flex-row items-center space-x-2">
+							{#if currentColorId}
+								<span
+									class="w-3 h-3 rounded-full border border-theme-accent/20"
+									style="background-color: {isDark ? COLOR_TOKENS[currentColorId].darkHex : COLOR_TOKENS[currentColorId].lightHex}"
+									aria-hidden="true"
+								></span>
+							{/if}
+							<span aria-hidden="true" class="opacity-60">›</span>
+						</span>
+					</button>
+				{:else if item.id !== 'play' && item.show}
 					<DropdownItem class={dropdownItemClasses} on:click={item.handler} data-umami-event={item.analyticsEvent}>
 						<svelte:component this={item.icon} />
 						<span>{item.text}</span>
@@ -187,5 +349,67 @@
 				</DropdownItem>
 			{/each}
 		</div>
+	{:else}
+		<div transition:fly={{ duration: 150, x: 8, easing: sineIn }} role="menu" tabindex="-1" aria-label="Bookmark colors" on:keydown={handleSubmenuKeydown} class="w-56 md:w-64 p-3">
+			<button
+				class="flex items-center space-x-1 text-xs font-medium opacity-70 hover:opacity-100 mb-2 px-1 py-1 rounded-3xl hover:bg-theme-accent/5 focus-visible:ring-2 focus-visible:ring-theme-accent focus-visible:ring-offset-2 focus-visible:outline-none"
+				on:click|stopPropagation|preventDefault={closeSubMenu}
+				aria-label="Back to verse options"
+			>
+				<span aria-hidden="true">‹</span><span>Back</span>
+			</button>
+
+			<div class="px-1 pb-2 text-xs font-semibold opacity-70">8 colors</div>
+
+			<div class="grid grid-cols-4 gap-2" role="group" aria-label="Bookmark colors">
+				{#each colorIds as id}
+					{@const token = COLOR_TOKENS[id]}
+					{@const isSelected = currentColorId === id}
+					{@const bg = isDark ? token.darkHex : token.lightHex}
+					<button
+						role="menuitemradio"
+						aria-checked={isSelected}
+						aria-label="Set {token.name} (color {id})"
+						title={token.name}
+						tabindex={isSelected || (!currentColorId && id === 1) ? 0 : -1}
+						class="w-7 h-7 md:w-7 md:h-7 rounded-full border flex items-center justify-center transition-all duration-150 hover:scale-105 hover:brightness-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-theme-accent focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg focus:outline-none {isSelected
+							? 'ring-2 ring-theme-accent ring-offset-2 ring-offset-theme-bg border-transparent'
+							: 'border-theme-accent/20 hover:border-theme-accent/40'}"
+						style="background-color: {bg}"
+						on:click|stopPropagation|preventDefault={() => handleSelectColor(id)}
+					>
+						{#if isSelected}
+							<span aria-hidden="true" class="text-[10px] font-bold" style="color: {isDark ? '#fff' : '#000'}; text-shadow: 0 0 2px rgba(0,0,0,0.2)">✓</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+
+			<button
+				role="menuitem"
+				aria-disabled={!currentColorId}
+				disabled={!currentColorId}
+				class="mt-3 w-full flex flex-row items-center justify-center space-x-2 text-xs px-3 py-2 rounded-3xl border border-transparent hover:bg-theme-accent/5 focus-visible:ring-2 focus-visible:ring-theme-accent focus:outline-none {currentColorId
+					? 'opacity-100'
+					: 'opacity-40 cursor-not-allowed pointer-events-none'}"
+				on:click|stopPropagation|preventDefault={handleClearColor}
+			>
+				<Trash size={3} aria-hidden="true" />
+				<span>Clear color</span>
+			</button>
+
+			{#if storageError}
+				<div role="alert" aria-live="assertive" class="mt-2 text-xs text-red-600 px-2">{storageError}</div>
+			{/if}
+			<div aria-live="polite" class="sr-only">{currentColorName ? `Color ${currentColorName} saved` : ''}</div>
+		</div>
 	{/if}
 </Dropdown>
+
+<style>
+	@media (prefers-reduced-motion: reduce) {
+		:global(*) {
+			transition: none !important;
+		}
+	}
+</style>

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -59,6 +59,7 @@ export const defaultSettings = {
 	userBookmarks: [],
 	userFavoriteChapters: [],
 	userNotes: {},
+	userColoredBookmarks: {},
 	chapter: 1,
 	offlineModeSettings: {}
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,10 +16,11 @@
 	import Edit2 from '$svgs/Edit2.svelte';
 	import UserBookmarks from '$display/UserBookmarks.svelte';
 	import UserNotes from '$display/UserNotes.svelte';
+	import UserColoredBookmarks from '$display/UserColoredBookmarks.svelte';
 	import QuranDivisionCard from '$display/QuranDivisionCard.svelte';
 	import Tooltip from '$ui/FlowbiteSvelte/tooltip/Tooltip.svelte';
 	import { websiteTagline } from '$data/websiteSettings';
-	import { __currentPage, __lastRead, __siteNavigationModalVisible, __quranNavigationModalVisible, __userBookmarks, __userNotes, __wideWesbiteLayoutEnabled, __homepageLayoutPreferences, __userFavoriteChapters, __favoriteChaptersModalVisible } from '$utils/stores';
+	import { __currentPage, __lastRead, __siteNavigationModalVisible, __quranNavigationModalVisible, __userBookmarks, __userNotes, __userColoredBookmarks, __wideWesbiteLayoutEnabled, __homepageLayoutPreferences, __userFavoriteChapters, __favoriteChaptersModalVisible } from '$utils/stores';
 	import { updateSettings } from '$utils/updateSettings';
 	import { quranMetaData, juzMeta, hizbMeta, mostRead } from '$data/quranMeta';
 	import { term } from '$utils/terminologies';
@@ -40,6 +41,7 @@
 	const bookmarksTab = 1;
 	const notesTab = 2;
 	const suggestionsTab = 3;
+	const coloredTab = 4;
 	const chaptersTab = 1;
 	const juzTab = 2;
 	const favoriteChaptersTab = 3;
@@ -58,6 +60,23 @@
 	$: lastReadExists = Object.prototype.hasOwnProperty.call($__lastRead, 'chapter');
 	$: totalBookmarks = $__userBookmarks.length;
 	$: totalNotes = Object.keys($__userNotes).length;
+	$: totalColored = (() => {
+		try {
+			const map = $__userColoredBookmarks ?? {};
+			return Object.keys(map).filter((k) => {
+				// lightweight validation: must be chapter:verse with numbers
+				const parts = k.split(':');
+				if (parts.length !== 2) return false;
+				const ch = Number(parts[0]);
+				const vs = Number(parts[1]);
+				if (!Number.isInteger(ch) || !Number.isInteger(vs)) return false;
+				const col = Number(map[k]);
+				return col >= 1 && col <= 8;
+			}).length;
+		} catch {
+			return 0;
+		}
+	})();
 	$: hasFavorites = $__userFavoriteChapters.length > 0;
 	$: favoritesSortIsAscending = homepageLayoutPreferences.favoritesSortIsAscending ?? true;
 	$: sortedFavoriteChapters = favoritesSortIsAscending ? [...$__userFavoriteChapters].sort((a, b) => a - b) : [...$__userFavoriteChapters].sort((a, b) => b - a);
@@ -227,15 +246,51 @@
 		<div id="extras-tabs" class="flex items-center justify-between">
 			<div class="flex flex-row justify-center">
 				<div class="flex text-sm font-medium text-center justify-center space-x-1 md:space-x-4 rounded-full py-2 {!homepageLayoutPreferences.extrasPanelVisible && disabledClasses}">
-					<button on:click={() => changeTabs('extrasActiveTab', bookmarksTab)} class="{extrasActiveTab === bookmarksTab ? tabActiveBorder : tabDefaultBorder} flex flex-row space-x-1 items-center truncate" data-umami-event="Bookmarks Tab Button">
+					<button
+						on:click={() => changeTabs('extrasActiveTab', bookmarksTab)}
+						class="{extrasActiveTab === bookmarksTab ? tabActiveBorder : tabDefaultBorder} flex flex-row space-x-1 items-center truncate"
+						data-umami-event="Bookmarks Tab Button"
+						role="tab"
+						aria-selected={extrasActiveTab === bookmarksTab}
+						aria-controls="bookmarks-tab-panel"
+						id="bookmarks-tab"
+					>
 						<span>Bookmarks</span>
 						<span>{totalBookmarks > 0 ? `(${totalBookmarks})` : ''}</span>
 					</button>
-					<button on:click={() => changeTabs('extrasActiveTab', notesTab)} class="{extrasActiveTab === notesTab ? tabActiveBorder : tabDefaultBorder} flex flex-row space-x-1 items-center truncate" data-umami-event="Notes Tab Button">
+					<button
+						on:click={() => changeTabs('extrasActiveTab', notesTab)}
+						class="{extrasActiveTab === notesTab ? tabActiveBorder : tabDefaultBorder} flex flex-row space-x-1 items-center truncate"
+						data-umami-event="Notes Tab Button"
+						role="tab"
+						aria-selected={extrasActiveTab === notesTab}
+						aria-controls="notes-tab-panel"
+						id="notes-tab"
+					>
 						<span>Notes</span>
 						<span>{totalNotes > 0 ? `(${totalNotes})` : ''}</span>
 					</button>
-					<button on:click={() => changeTabs('extrasActiveTab', suggestionsTab)} class={extrasActiveTab === suggestionsTab ? tabActiveBorder : tabDefaultBorder} data-umami-event="Suggestions Tab Button">Suggestions</button>
+					<button
+						on:click={() => changeTabs('extrasActiveTab', suggestionsTab)}
+						class={extrasActiveTab === suggestionsTab ? tabActiveBorder : tabDefaultBorder}
+						data-umami-event="Suggestions Tab Button"
+						role="tab"
+						aria-selected={extrasActiveTab === suggestionsTab}
+						aria-controls="suggestions-tab-panel"
+						id="suggestions-tab"
+					>Suggestions</button>
+					<button
+						on:click={() => changeTabs('extrasActiveTab', coloredTab)}
+						class="{extrasActiveTab === coloredTab ? tabActiveBorder : tabDefaultBorder} flex flex-row space-x-1 items-center truncate"
+						data-umami-event="Colored Bookmarks Tab Button"
+						role="tab"
+						aria-selected={extrasActiveTab === coloredTab}
+						aria-controls="colored-tab-panel"
+						id="colored-tab"
+					>
+						<span>Colored</span>
+						<span>{totalColored > 0 ? `(${totalColored})` : ''}</span>
+					</button>
 				</div>
 			</div>
 
@@ -270,6 +325,11 @@
 
 					<div class="px-2 text-xs opacity-70">Suggestions listed here are based on the most frequently read chapters and verses by muslim audience, as well as virtues derived from Hadiths. While some Hadiths highlighting these virtues may be considered weak by some scholars, using them for beneficial knowledge is also a widely accepted opinion.</div>
 				</div>
+			</div>
+
+			<!-- colored bookmarks tab -->
+			<div class="space-y-12 {extrasActiveTab === coloredTab ? 'block' : 'hidden'}" id="colored-tab-panel" role="tabpanel" aria-labelledby="colored-tab">
+				<UserColoredBookmarks {cardGridClasses} {cardInnerClasses} />
 			</div>
 		</div>
 

--- a/src/utils/coloredBookmarks.js
+++ b/src/utils/coloredBookmarks.js
@@ -1,0 +1,245 @@
+import { get } from 'svelte/store';
+import { __userColoredBookmarks } from '$utils/stores';
+import { isValidVerseKey } from '$utils/validateKey';
+
+// Palette tokens — design-spec §3.2 (8 colors) — FIX-006: bumped opacity for visibility, hex unchanged
+export const COLOR_TOKENS = {
+	1: { id: 1, name: 'Amber Glow', lightHex: '#EADDB8', darkHex: '#B9973F', lightOpacity: 0.28, darkOpacity: 0.34 },
+	2: { id: 2, name: 'Terracotta Dune', lightHex: '#E6D0C0', darkHex: '#C07A5A', lightOpacity: 0.26, darkOpacity: 0.32 },
+	3: { id: 3, name: 'Rose Ash', lightHex: '#E5D1D1', darkHex: '#B07A7A', lightOpacity: 0.24, darkOpacity: 0.3 },
+	4: { id: 4, name: 'Lavender Mist', lightHex: '#DDD4E8', darkHex: '#8E7AAE', lightOpacity: 0.26, darkOpacity: 0.32 },
+	5: { id: 5, name: 'Powder Slate', lightHex: '#D2DDE5', darkHex: '#7A9AB5', lightOpacity: 0.26, darkOpacity: 0.32 },
+	6: { id: 6, name: 'Sage Teal', lightHex: '#D1E0DD', darkHex: '#7AA89B', lightOpacity: 0.24, darkOpacity: 0.3 },
+	7: { id: 7, name: 'Olive Sage', lightHex: '#D9E0C9', darkHex: '#8FA67A', lightOpacity: 0.24, darkOpacity: 0.3 },
+	8: { id: 8, name: 'Stone Taupe', lightHex: '#E0DCD6', darkHex: '#9A8F86', lightOpacity: 0.22, darkOpacity: 0.3 }
+};
+
+export const VALID_COLOR_IDS = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
+
+const DARK_THEMES = new Set([5, 6, 7, 8, 9]);
+
+export function isValidColorId(v) {
+	const n = Number(v);
+	return Number.isInteger(n) && VALID_COLOR_IDS.has(n);
+}
+
+export function isDarkTheme(websiteTheme) {
+	return DARK_THEMES.has(Number(websiteTheme));
+}
+
+function normalizeVerseKey(key) {
+	if (typeof key !== 'string') return null;
+	const trimmed = key.trim();
+	if (!trimmed) return null;
+	const parts = trimmed.split(':');
+	if (parts.length !== 2) return null;
+	const ch = Number(parts[0]);
+	const vs = Number(parts[1]);
+	if (!Number.isInteger(ch) || !Number.isInteger(vs)) return null;
+	return `${ch}:${vs}`;
+}
+
+function canonicalCompare(a, b) {
+	const [ca, va] = a.split(':').map(Number);
+	const [cb, vb] = b.split(':').map(Number);
+	if (ca !== cb) return ca - cb;
+	return va - vb;
+}
+
+function readMap() {
+	try {
+		const store = get(__userColoredBookmarks);
+		if (store && typeof store === 'object' && !Array.isArray(store)) return store;
+	} catch {
+		// store not yet initialized (SSR or early)
+	}
+	// fallback to localStorage directly
+	try {
+		const raw = localStorage.getItem('userSettings');
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		const map = parsed?.userColoredBookmarks;
+		if (map && typeof map === 'object' && !Array.isArray(map)) return map;
+	} catch {
+		// ignore
+	}
+	return {};
+}
+
+// Public helpers — api-spec §7
+
+export function getColorForVerse(key) {
+	if (!key || typeof key !== 'string') return null;
+	const normalized = normalizeVerseKey(key);
+	if (!normalized) return null;
+	if (!isValidVerseKey(normalized)) return null;
+	const map = readMap();
+	const val = map[normalized];
+	if (val == null) return null;
+	const n = Number(val);
+	return isValidColorId(n) ? n : null;
+}
+
+export function getVersesByColor(colorId) {
+	const n = Number(colorId);
+	if (!isValidColorId(n)) return [];
+	const map = readMap();
+	const out = [];
+	for (const [k, v] of Object.entries(map)) {
+		if (Number(v) === n && isValidVerseKey(k)) out.push(k);
+	}
+	out.sort(canonicalCompare);
+	return out;
+}
+
+export function getColoredBookmarksGrouped() {
+	const map = readMap();
+	const byColor = { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [], 7: [], 8: [] };
+	const all = [];
+	for (const [k, v] of Object.entries(map)) {
+		const n = Number(v);
+		if (!isValidVerseKey(k)) continue;
+		if (!isValidColorId(n)) continue;
+		all.push(k);
+		byColor[n].push(k);
+	}
+	all.sort(canonicalCompare);
+	for (let i = 1; i <= 8; i++) byColor[i].sort(canonicalCompare);
+	const counts = {
+		total: all.length,
+		byColor: {
+			1: byColor[1].length,
+			2: byColor[2].length,
+			3: byColor[3].length,
+			4: byColor[4].length,
+			5: byColor[5].length,
+			6: byColor[6].length,
+			7: byColor[7].length,
+			8: byColor[8].length
+		}
+	};
+	return { byColor, all, counts, isEmpty: all.length === 0 };
+}
+
+export function getTotalColoredCount() {
+	return getColoredBookmarksGrouped().counts.total;
+}
+
+export function getPerColorCounts() {
+	return getColoredBookmarksGrouped().counts.byColor;
+}
+
+export function hasColor(key) {
+	return getColorForVerse(key) !== null;
+}
+
+export function getAllColoredKeysSorted() {
+	return getColoredBookmarksGrouped().all;
+}
+
+export function hexToRgb(hex) {
+	if (!hex || typeof hex !== 'string') return null;
+	let h = hex.trim().replace(/^#/, '');
+	if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+	if (h.length !== 6) return null;
+	const r = parseInt(h.slice(0, 2), 16);
+	const g = parseInt(h.slice(2, 4), 16);
+	const b = parseInt(h.slice(4, 6), 16);
+	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+	return { r, g, b };
+}
+
+export function getVerseTintStyle(colorId, websiteTheme) {
+	const n = Number(colorId);
+	if (!isValidColorId(n)) return '';
+	const token = COLOR_TOKENS[n];
+	const isDark = isDarkTheme(websiteTheme);
+	const hex = isDark ? token.darkHex : token.lightHex;
+	const opacity = isDark ? token.darkOpacity : token.lightOpacity;
+	const rgb = hexToRgb(hex);
+	if (!rgb) return '';
+	return `background-color: rgba(${rgb.r},${rgb.g},${rgb.b},${opacity})`;
+}
+
+// Tint class helpers — design-spec §3.2 / §4.2
+// Deprecated: Tailwind arbitrary bg-[#hex]/pct is purged at runtime — use getVerseTintStyle instead.
+// Kept for backward compatibility / tests but verse wrappers must use style attribute.
+export function getVerseTintClasses(colorId, websiteTheme) {
+	const n = Number(colorId);
+	if (!isValidColorId(n)) return '';
+	const token = COLOR_TOKENS[n];
+	const isDark = isDarkTheme(websiteTheme);
+	const hex = isDark ? token.darkHex : token.lightHex;
+	const opacity = isDark ? token.darkOpacity : token.lightOpacity;
+	// opacity *100 for Tailwind slash syntax (e.g. 0.14 -> 14)
+	// Use non-integer safe: Math.round(opacity*100)
+	const pct = Math.round(opacity * 100);
+	return `bg-[${hex}]/${pct}`;
+}
+
+// Full tint wrapper classes to apply to verse container
+// isInline = true for Continuous (inline) wrapper, false for block modes
+// NOTE: FIX-004 — wrappers now use inline style via getVerseTintStyle to avoid Tailwind purge.
+// This helper is kept for backward compatibility / tests but should not be used for runtime bg.
+export function getVerseTintWrapperClasses(colorId, websiteTheme, isInline = false) {
+	if (!colorId) return '';
+	const bg = getVerseTintClasses(colorId, websiteTheme);
+	if (!bg) return '';
+	if (isInline) {
+		// box-decoration-clone ensures multi-line inline tint clones per line
+		return `${bg} rounded-lg px-1.5 py-1 box-decoration-clone transition-colors duration-200`;
+	}
+	return `${bg} rounded-xl transition-colors duration-200`;
+}
+
+// Border accent for cards (solid token at full opacity border)
+export function getCardBorderColor(colorId, websiteTheme) {
+	const n = Number(colorId);
+	if (!isValidColorId(n)) return '';
+	const token = COLOR_TOKENS[n];
+	const isDark = isDarkTheme(websiteTheme);
+	return isDark ? token.darkHex : token.lightHex;
+}
+
+// Alias map for api-spec §3.1 color param (not needed in helper but exported for updateSettings reuse)
+export const COLOR_ALIAS_MAP = {
+	amber: 1,
+	amberglow: 1,
+	'amber-glow': 1,
+	terracotta: 2,
+	dune: 2,
+	terracottadune: 2,
+	'terracotta-dune': 2,
+	rose: 3,
+	roseash: 3,
+	'rose-ash': 3,
+	lavender: 4,
+	mist: 4,
+	lavendermist: 4,
+	'lavender-mist': 4,
+	slate: 5,
+	powder: 5,
+	powderslate: 5,
+	'powder-slate': 5,
+	sage: 6,
+	teal: 6,
+	sageteal: 6,
+	'sage-teal': 6,
+	olive: 7,
+	olivesage: 7,
+	'olive-sage': 7,
+	stone: 8,
+	taupe: 8,
+	stonetaupe: 8,
+	'stone-taupe': 8
+};
+
+export function resolveColorAlias(input) {
+	if (input == null) return null;
+	const s = String(input).trim().toLowerCase();
+	if (/^[1-8]$/.test(s)) return Number(s);
+	if (COLOR_ALIAS_MAP[s] != null) return COLOR_ALIAS_MAP[s];
+	const n = Number(s);
+	if (isValidColorId(n)) return n;
+	return null;
+}

--- a/src/utils/stores.js
+++ b/src/utils/stores.js
@@ -10,6 +10,7 @@ let __currentPage,
 	__userSettings,
 	__userNotes,
 	__userBookmarks,
+	__userColoredBookmarks,
 	__userFavoriteChapters,
 	__fontType,
 	__wordTranslation,
@@ -90,6 +91,9 @@ if (browser) {
 
 	// to store the user bookmarks
 	__userBookmarks = writable(userSettings.userBookmarks);
+
+	// to store the user's colored bookmarks (Record<verseKey, 1..8>)
+	__userColoredBookmarks = writable(userSettings.userColoredBookmarks ?? {});
 
 	// to store the user's favorite chapters
 	__userFavoriteChapters = writable(userSettings.userFavoriteChapters);
@@ -237,6 +241,7 @@ export {
 	__userSettings,
 	__userNotes,
 	__userBookmarks,
+	__userColoredBookmarks,
 	__userFavoriteChapters,
 	__fontType,
 	__wordTranslation,

--- a/src/utils/updateSettings.js
+++ b/src/utils/updateSettings.js
@@ -19,6 +19,7 @@ import {
 	__lastRead,
 	__wordTooltip,
 	__userBookmarks,
+	__userColoredBookmarks,
 	__userFavoriteChapters,
 	__wakeLockEnabled,
 	__userNotes,
@@ -34,12 +35,15 @@ import {
 	__homepageLayoutPreferences
 } from '$utils/stores';
 import { fetchChapterData, fetchVerseTranslationData } from '$utils/fetchData';
+import { isValidVerseKey } from '$utils/validateKey';
 
 // function to update website settings
 export function updateSettings(props) {
 	// get the settings from localStorage
 	const userSettings = JSON.parse(localStorage.getItem('userSettings'));
 	let trackEvent = false;
+	let coloredResult = null;
+	let skipGenericPersist = false;
 	// let uploadSettings = false;
 
 	switch (props.type) {
@@ -321,6 +325,200 @@ export function updateSettings(props) {
 			userSettings.offlineModeSettings = props.value;
 			break;
 
+		case 'userColoredBookmarks': {
+			const VALID_COLOR_IDS = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
+			const isValidColorId = (v) => {
+				const n = Number(v);
+				return Number.isInteger(n) && VALID_COLOR_IDS.has(n);
+			};
+			const COLOR_ALIAS_MAP = {
+				amber: 1,
+				amberglow: 1,
+				'amber-glow': 1,
+				terracotta: 2,
+				dune: 2,
+				terracottadune: 2,
+				'terracotta-dune': 2,
+				rose: 3,
+				roseash: 3,
+				'rose-ash': 3,
+				lavender: 4,
+				mist: 4,
+				lavendermist: 4,
+				'lavender-mist': 4,
+				slate: 5,
+				powder: 5,
+				powderslate: 5,
+				'powder-slate': 5,
+				sage: 6,
+				teal: 6,
+				sageteal: 6,
+				'sage-teal': 6,
+				olive: 7,
+				olivesage: 7,
+				'olive-sage': 7,
+				stone: 8,
+				taupe: 8,
+				stonetaupe: 8,
+				'stone-taupe': 8
+			};
+			const resolveColorAlias = (input) => {
+				if (input == null) return null;
+				const s = String(input).trim().toLowerCase();
+				if (/^[1-8]$/.test(s)) return Number(s);
+				if (COLOR_ALIAS_MAP[s] != null) return COLOR_ALIAS_MAP[s];
+				const n = Number(s);
+				if (isValidColorId(n)) return n;
+				return null;
+			};
+
+			const isQuotaError = (e) => e && (e.code === 22 || e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+
+			// ensure map exists
+			if (!userSettings.userColoredBookmarks || typeof userSettings.userColoredBookmarks !== 'object' || Array.isArray(userSettings.userColoredBookmarks)) {
+				userSettings.userColoredBookmarks = {};
+			}
+			const snapshot = JSON.parse(JSON.stringify(userSettings.userColoredBookmarks));
+
+			let result = null;
+			try {
+				// bulk override
+				if (props.override !== undefined && props.override !== false && props.override !== null) {
+					const bulk = props.override;
+					if (typeof bulk !== 'object' || Array.isArray(bulk)) {
+						result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: 'override must be Record<verseKey, colorId>' } };
+					} else {
+						const invalid = [];
+						const normalizedBulk = {};
+						for (const [k, v] of Object.entries(bulk)) {
+							if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+								invalid.push(k);
+								continue;
+							}
+							const normKey = (() => {
+								const t = String(k).trim();
+								const parts = t.split(':');
+								if (parts.length !== 2) return t;
+								return `${Number(parts[0])}:${Number(parts[1])}`;
+							})();
+							if (!isValidVerseKey(normKey)) {
+								invalid.push(k);
+								continue;
+							}
+							const n = Number(v);
+							if (!isValidColorId(n)) {
+								invalid.push(k);
+								continue;
+							}
+							normalizedBulk[normKey] = n;
+						}
+						if (invalid.length > 0) {
+							result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid entries: ${invalid.join(', ')}`, details: { invalidKeys: invalid } } };
+						} else {
+							userSettings.userColoredBookmarks = normalizedBulk;
+							if (Object.keys(normalizedBulk).length > 0) window.umami?.track('Colored Bookmarks Bulk Override', { count: Object.keys(normalizedBulk).length });
+							result = { status: 200, ok: true, action: 'bulk', totalColored: Object.keys(normalizedBulk).length };
+						}
+					}
+				} else {
+					// single verse mode
+					if (!props.key) {
+						result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: 'verseKey required' } };
+					} else {
+						const rawKey = String(props.key).trim();
+						const parts = rawKey.split(':');
+						const normalizedKey = parts.length === 2 ? `${Number(parts[0])}:${Number(parts[1])}` : rawKey;
+						if (normalizedKey === '__proto__' || normalizedKey === 'constructor' || normalizedKey === 'prototype') {
+							result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid verseKey' } };
+						} else if (!isValidVerseKey(normalizedKey)) {
+							result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid verseKey "${props.key}": failed isValidVerseKey`, details: { key: props.key, constraint: 'isValidVerseKey' } } };
+						} else if (props.clear) {
+							const existing = userSettings.userColoredBookmarks[normalizedKey];
+							if (existing == null) {
+								result = { status: 204, ok: true, key: normalizedKey, action: 'noop', totalColored: Object.keys(userSettings.userColoredBookmarks).length };
+							} else {
+								const cleared = existing;
+								delete userSettings.userColoredBookmarks[normalizedKey];
+								window.umami?.track('Colored Bookmark Clear', { verseKey: normalizedKey, clearedColorId: cleared });
+								result = { status: 200, ok: true, key: normalizedKey, action: 'clear', totalColored: Object.keys(userSettings.userColoredBookmarks).length };
+							}
+						} else {
+							let colorId = null;
+							if (props.colorId !== undefined && props.colorId !== null) colorId = Number(props.colorId);
+							else if (props.color !== undefined && props.color !== null) colorId = resolveColorAlias(props.color);
+							if (colorId == null || !isValidColorId(colorId)) {
+								result = { status: 400, ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid colorId "${props.colorId ?? props.color}"`, details: { colorId: props.colorId ?? props.color, allowed: [1, 2, 3, 4, 5, 6, 7, 8] } } };
+							} else {
+								const existing = userSettings.userColoredBookmarks[normalizedKey];
+								if (existing === colorId) {
+									result = { status: 204, ok: true, key: normalizedKey, colorId, action: 'noop', totalColored: Object.keys(userSettings.userColoredBookmarks).length };
+								} else {
+									const action = existing == null ? 'set' : 'replace';
+									userSettings.userColoredBookmarks[normalizedKey] = colorId;
+									if (action === 'set') {
+										const names = { 1: 'Amber Glow', 2: 'Terracotta Dune', 3: 'Rose Ash', 4: 'Lavender Mist', 5: 'Powder Slate', 6: 'Sage Teal', 7: 'Olive Sage', 8: 'Stone Taupe' };
+										window.umami?.track('Colored Bookmark Set', { verseKey: normalizedKey, colorId, colorName: names[colorId] ?? String(colorId) });
+									} else {
+										window.umami?.track('Colored Bookmark Change', { verseKey: normalizedKey, fromColorId: existing, toColorId: colorId });
+									}
+									result = { status: 200, ok: true, key: normalizedKey, colorId, action, totalColored: Object.keys(userSettings.userColoredBookmarks).length };
+								}
+							}
+						}
+					}
+				}
+
+				// validation error -> revert & return
+				if (result && result.status === 400) {
+					userSettings.userColoredBookmarks = snapshot;
+					coloredResult = result;
+					skipGenericPersist = true;
+					break;
+				}
+				if (result && result.status === 204) {
+					// noop -> no write needed, but ensure store sync (no change)
+					coloredResult = result;
+					skipGenericPersist = true;
+					// restore snapshot to be safe (no mutation)
+					userSettings.userColoredBookmarks = snapshot;
+					// check if we actually didn't mutate (noop case restored)
+					// but if noop we already rewound; need to keep original map
+					// For noop, snapshot === current, so keep snapshot
+					break;
+				}
+				// success write path
+				try {
+					__userColoredBookmarks.set(userSettings.userColoredBookmarks);
+					__userSettings.set(JSON.stringify(userSettings));
+					localStorage.setItem('userSettings', JSON.stringify(userSettings));
+					coloredResult = result;
+				} catch (e) {
+					userSettings.userColoredBookmarks = snapshot;
+					try {
+						__userColoredBookmarks.set(snapshot);
+					} catch (_err) {
+						// ignore
+					}
+					if (isQuotaError(e)) {
+						coloredResult = { status: 507, ok: false, error: { code: 'QUOTA_EXCEEDED', message: 'Storage full — couldn\'t save color. Try clearing old bookmarks/notes and retry.' } };
+					} else {
+						coloredResult = { status: 500, ok: false, error: { code: 'STORAGE_ERROR', message: e.message || 'Storage error' } };
+					}
+				}
+				skipGenericPersist = true;
+			} catch (e) {
+				userSettings.userColoredBookmarks = snapshot;
+				try {
+					__userColoredBookmarks.set(snapshot);
+				} catch (_err) {
+					// ignore
+				}
+				coloredResult = { status: 500, ok: false, error: { code: 'STORAGE_ERROR', message: e.message || 'Storage error' } };
+				skipGenericPersist = true;
+			}
+			break;
+		}
+
 		// for homepage layout preferences
 		case 'homepageLayoutPreferences':
 			__homepageLayoutPreferences.set(props.value);
@@ -357,9 +555,14 @@ export function updateSettings(props) {
 		// window.umami.track('Setting Change', { type: props.type, value: props.value });
 	}
 
+	if (skipGenericPersist) {
+		return coloredResult;
+	}
+
 	// update the settings back into localStorage and global store
 	__userSettings.set(JSON.stringify(userSettings));
 	localStorage.setItem('userSettings', JSON.stringify(userSettings));
+	return { status: 200, ok: true };
 }
 
 // Toggle downloaded data setting (add if not present, remove if present)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,14 @@
 import colors from 'tailwindcss/colors';
 import flowbitePlugin from 'flowbite/plugin';
 import tailwindScrollbar from 'tailwind-scrollbar';
+import log from 'tailwindcss/lib/util/log.js';
+
+// Omit deprecated aliases renamed in Tailwind v2.2+ (lightBlue→sky etc) to silence warns; behavior identical
+// Tailwind's colors getters warn on access, so temporarily silence log.warn during destructure
+const _origWarn = log.default?.warn;
+if (log.default && _origWarn) log.default.warn = () => {};
+const { lightBlue: _lightBlue, warmGray: _warmGray, trueGray: _trueGray, coolGray: _coolGray, blueGray: _blueGray, ...supportedColors } = colors;
+if (log.default && _origWarn) log.default.warn = _origWarn;
 
 export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
@@ -9,7 +17,7 @@ export default {
 	theme: {
 		extend: {
 			colors: {
-				...colors,
+				...supportedColors,
 
 				// These three entries cover ALL themes
 				theme: {

--- a/tests/__mocks__/app-environment.js
+++ b/tests/__mocks__/app-environment.js
@@ -1,0 +1,4 @@
+export const browser = true;
+export const building = false;
+export const dev = true;
+export const version = 'test';

--- a/tests/e2e/colored-bookmark.e2e.spec.js
+++ b/tests/e2e/colored-bookmark.e2e.spec.js
@@ -1,0 +1,228 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: Colored Bookmark — submenu beneath Advanced Play, 8 colors tint,
+ * homepage grouping, persistence reload.
+ * Requires dev server (auto via playwright webServer).
+ * Mark @critical for webapp-testing skill evidence.
+ */
+
+test.describe('Colored Bookmark E2E', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		// clear storage and reload to ensure defaultSettings migration
+		await page.evaluate(() => localStorage.clear());
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('AC1 @critical submenu appears beneath Advanced Play with 8 swatches + Clear', async ({ page }) => {
+		// navigate to a chapter with verses
+		await page.goto('/2?startVerse=255');
+		await page.waitForSelector('.verse', { timeout: 10000 });
+
+		// open verse 2:255 options: trigger id is verse-options-{verse}
+		const trigger = page.locator('#verse-options-255').first();
+		await expect(trigger).toBeVisible();
+		await trigger.click();
+
+		// dropdown should show Advanced Play then Colored Bookmark row
+		const advancedPlay = page.getByText('Advanced Play');
+		await expect(advancedPlay).toBeVisible();
+
+		const coloredRow = page.getByRole('menuitem', { name: /Colored Bookmark/ });
+		await expect(coloredRow).toBeVisible();
+
+		// verify ordering: Colored Bookmark immediately after Advanced Play (checked via visibility)
+		await coloredRow.click();
+
+		// submenu appears
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible();
+
+		// 8 swatches as menuitemradio
+		const swatches = page.getByRole('menuitemradio');
+		await expect(swatches).toHaveCount(8);
+		for (let i = 1; i <= 8; i++) {
+			await expect(page.getByLabel(`Set`, { exact: false }).first()).toBeVisible();
+		}
+		// header 8 colors
+		await expect(page.getByText('8 colors')).toBeVisible();
+
+		// Clear color disabled initially
+		const clearBtn = page.getByRole('menuitem', { name: 'Clear color' });
+		await expect(clearBtn).toBeVisible();
+		await expect(clearBtn).toBeDisabled();
+
+		// Back button
+		await expect(page.getByRole('button', { name: /Back to verse options/ })).toBeVisible();
+
+		// Escape returns to main menu
+		await page.keyboard.press('Escape');
+		await expect(submenu).toBeHidden();
+		await expect(coloredRow).toBeVisible();
+
+		// console errors check
+		const consoleErrors = [];
+		page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+		expect(consoleErrors.filter(m => !m.includes('Failed to load'))).toEqual([]);
+
+		await page.screenshot({ path: 'test-results/e2e-submenu.png', fullPage: false });
+	});
+
+	test('AC2 select color tints verse and persists reload @critical', async ({ page }) => {
+		await page.goto('/2?startVerse=255');
+		await page.waitForSelector('.verse', { timeout: 10000 });
+
+		const trigger = page.locator('#verse-options-255').first();
+		await trigger.click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+
+		// select Amber Glow (id 1) - first swatch
+		const amber = page.getByRole('menuitemradio', { name: /Amber Glow/ });
+		await expect(amber).toBeVisible();
+		await amber.click();
+
+		// verse wrapper should have tint class bg-[#EADDB8]/14 or dark variant
+		const verse = page.locator('#2\\:255');
+		await expect(verse).toBeVisible();
+		// check class contains bg-[
+		await expect(verse).toHaveClass(/bg-\[#/);
+
+		// localStorage check
+		const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks);
+		expect(stored['2:255']).toBe(1);
+
+		// reload → tint persists
+		await page.reload();
+		await page.waitForSelector('#2\\:255', { timeout: 10000 });
+		const verseReloaded = page.locator('#2\\:255');
+		await expect(verseReloaded).toHaveClass(/bg-\[#/);
+
+		// re-open submenu, selected ring visible
+		await page.locator('#verse-options-255').first().click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const amberAfter = page.getByRole('menuitemradio', { name: /Amber Glow/ });
+		await expect(amberAfter).toHaveAttribute('aria-checked', 'true');
+		await expect(amberAfter.locator('text=✓')).toBeVisible();
+
+		// replace with different color (Lavender Mist id 4)
+		await page.getByRole('menuitemradio', { name: /Lavender Mist/ }).click();
+		const updated = await page.evaluate(() => JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks['2:255']);
+		expect(updated).toBe(4);
+
+		// clear
+		await page.locator('#verse-options-255').first().click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const clearBtn = page.getByRole('menuitem', { name: 'Clear color' });
+		await expect(clearBtn).toBeEnabled();
+		await clearBtn.click();
+		await expect(page.locator('#2\\:255')).not.toHaveClass(/bg-\[#/);
+		const cleared = await page.evaluate(() => JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks['2:255']);
+		expect(cleared).toBeUndefined();
+		// bookmarks invariant
+		const bookmarks = await page.evaluate(() => JSON.parse(localStorage.getItem('userSettings')).userBookmarks);
+		expect(Array.isArray(bookmarks)).toBeTruthy();
+
+		await page.screenshot({ path: 'test-results/e2e-tint.png', fullPage: false });
+	});
+
+	test('AC3 homepage Colored tab grouped by color @critical', async ({ page }) => {
+		// seed via localStorage directly
+		await page.evaluate(() => {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			raw.userColoredBookmarks = { '1:1': 1, '2:255': 1, '36:58': 4, '114:6': 8 };
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		});
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+
+		// click Colored tab
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await expect(coloredTab).toBeVisible();
+		await coloredTab.click();
+
+		// badge count (totalColored) should show (4)
+		await expect(coloredTab).toContainText('(4)');
+
+		// panel visible
+		const panel = page.locator('#colored-tab-panel');
+		await expect(panel).toBeVisible();
+
+		// per-color sections: check Amber Glow header count 2, Lavender Mist 1, Stone Taupe 1
+		await expect(page.locator('#colored-section-1')).toContainText('Amber Glow');
+		await expect(page.locator('#colored-section-1')).toContainText('(2)');
+		await expect(page.locator('#colored-section-4')).toContainText('Lavender Mist');
+		await expect(page.locator('#colored-section-4')).toContainText('(1)');
+		await expect(page.locator('#colored-section-8')).toContainText('(1)');
+
+		// sections with zero should show No verses and opacity-40
+		await expect(page.locator('#colored-section-2')).toContainText('No verses in Terracotta Dune');
+		await expect(page.locator('#colored-section-2')).toHaveClass(/opacity-40/);
+
+		// cards link to /{chapter}?startVerse={verse}
+		const firstCardLink = panel.locator('a[href*="?startVerse="]').first();
+		await expect(firstCardLink).toBeVisible();
+		const href = await firstCardLink.getAttribute('href');
+		expect(href).toMatch(/\/\d+\?startVerse=\d+/);
+
+		// clicking card navigates
+		await firstCardLink.click();
+		await expect(page).toHaveURL(/\/\d+\?startVerse=\d+/);
+
+		await page.screenshot({ path: 'test-results/e2e-homepage-grouped.png', fullPage: true });
+	});
+
+	test('AC3 empty state global', async ({ page }) => {
+		await page.goto('/');
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await coloredTab.click();
+		await expect(page.getByText(/No colored bookmarks yet/)).toBeVisible();
+		await expect(page.getByText(/Colored Bookmark to tint/)).toBeVisible();
+		// badge hidden when zero (no parentheses)
+		await expect(coloredTab).not.toContainText('(');
+	});
+
+	test('AC3 keyboard nav: tab switching and swatch grid @a11y', async ({ page }) => {
+		await page.goto('/2?startVerse=255');
+		await page.waitForSelector('#verse-options-255');
+		// Tab to trigger
+		await page.keyboard.press('Tab');
+		// find focused element maybe
+		await page.locator('#verse-options-255').first().focus();
+		await page.keyboard.press('Enter');
+		await expect(page.getByText('Advanced Play')).toBeVisible();
+		await page.keyboard.press('ArrowDown'); // maybe? just open colored via keyboard
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).focus();
+		await page.keyboard.press('Enter');
+		const firstSwatch = page.getByRole('menuitemradio').first();
+		await expect(firstSwatch).toBeFocused();
+		await page.keyboard.press('ArrowRight');
+		await expect(page.getByRole('menuitemradio').nth(1)).toBeFocused();
+		await page.keyboard.press('Escape');
+		await expect(page.getByRole('menu', { name: 'Bookmark colors' })).toBeHidden();
+	});
+
+	test('AC4 persistence: extrasActiveTab 4 survives reload', async ({ page }) => {
+		await page.goto('/');
+		await page.getByRole('tab', { name: /Colored/ }).click();
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+		// should still be selected
+		await expect(page.getByRole('tab', { name: /Colored/ })).toHaveAttribute('aria-selected', 'true');
+		await expect(page.locator('#colored-tab-panel')).toBeVisible();
+	});
+
+	test('mobile: submenu width and tint inline @mobile', async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await page.goto('/2?startVerse=255');
+		await page.waitForSelector('.verse');
+		await page.locator('#verse-options-255').first().click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible();
+		const box = await submenu.boundingBox();
+		expect(box.width).toBeGreaterThan(200);
+		expect(box.width).toBeLessThan(300); // w-56 = 224
+	});
+});

--- a/tests/e2e/test-002-fix-verification.e2e.spec.js
+++ b/tests/e2e/test-002-fix-verification.e2e.spec.js
@@ -1,0 +1,437 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * TEST-002 Verification: Tailwind silence + VerseOptionsDropdown submenu fix
+ * - Tailwind build zero rename warnings + zero browserslist stale (verified via build logs outside browser)
+ * - Menu stays open after clicking Colored Bookmark beneath Advanced Play
+ * - 4x2 grid, Back, Escape, swatch select tints + persists, Clear removes
+ * - Across desktop + mobile (Playwright projects: chromium + mobile) and light/dark themes (1 vs 5)
+ * Evidence: screenshots + console/network logs
+ */
+
+const EVIDENCE_DIR = 'test-results/test-002-evidence';
+const SCREENSHOT_DIR = 'test-results/test-002-screenshots';
+
+function ensureDirs() {
+	for (const d of [EVIDENCE_DIR, SCREENSHOT_DIR]) {
+		if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+	}
+}
+
+async function setWebsiteTheme(page, themeId) {
+	await page.evaluate((t) => {
+		try {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			if (!raw.displaySettings) raw.displaySettings = {};
+			raw.displaySettings.websiteTheme = t;
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		} catch {}
+		try {
+			document.documentElement.setAttribute('data-theme', String(t));
+		} catch {}
+	}, themeId);
+}
+
+async function gotoChapterVerse(page, chapter = 2, verse = 255) {
+	await page.goto(`/${chapter}?startVerse=${verse}`, { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+	// verses render async via fetch; wait for trigger
+	await page.waitForSelector(`#verse-options-${verse}`, { timeout: 15000 });
+	await page.waitForSelector('.verse', { timeout: 10000 }).catch(() => {});
+	// small settle for dropdown positioning
+	await page.waitForTimeout(400);
+}
+
+async function openVerseDropdown(page, verse = 255) {
+	const trigger = page.locator(`#verse-options-${verse}`).first();
+	await expect(trigger).toBeVisible({ timeout: 10000 });
+	await trigger.click();
+	await expect(page.getByText('Advanced Play')).toBeVisible({ timeout: 8000 });
+}
+
+test.describe('TEST-002: Tailwind fix + VerseOptionsDropdown submenu @critical', () => {
+	test.beforeAll(() => {
+		ensureDirs();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		// capture console/network for evidence
+		page._consoleLogs = [];
+		page._networkLogs = [];
+		page.on('console', (msg) => {
+			const entry = `[${msg.type()}] ${msg.text()}`;
+			page._consoleLogs.push(entry);
+		});
+		page.on('request', (req) => page._networkLogs.push(`REQ ${req.method()} ${req.url()}`));
+		page.on('response', (res) =>
+			page._networkLogs.push(`RES ${res.status()} ${res.url().slice(0, 120)}`)
+		);
+		page.on('pageerror', (err) => page._consoleLogs.push(`[pageerror] ${err.message}`));
+
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		await page.evaluate(() => localStorage.clear());
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+	});
+
+	test.afterEach(async ({ page }, testInfo) => {
+		// save console/network logs per test
+		const safeTitle = testInfo.title.replace(/[^a-z0-9]+/gi, '_').slice(0, 80);
+		const project = testInfo.project.name;
+		const base = `${EVIDENCE_DIR}/${project}_${safeTitle}`;
+		try {
+			fs.writeFileSync(`${base}.console.log`, (page._consoleLogs || []).join('\n') || '(no console)');
+			fs.writeFileSync(`${base}.network.log`, (page._networkLogs || []).join('\n').slice(0, 20000) || '(no network)');
+		} catch {}
+		if (testInfo.status !== testInfo.expectedStatus) {
+			await page.screenshot({ path: `${SCREENSHOT_DIR}/${project}_${safeTitle}_FAILURE.png`, fullPage: true }).catch(() => {});
+		}
+	});
+
+	test('TC01 menu stays open after clicking Colored Bookmark (light theme)', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+
+		const coloredRow = page.getByRole('menuitem', { name: /Colored Bookmark/ });
+		await expect(coloredRow).toBeVisible();
+		// ensure it is beneath Advanced Play: check DOM order
+		const advancedPlay = page.getByText('Advanced Play');
+		const advBox = await advancedPlay.boundingBox();
+		const colBox = await coloredRow.boundingBox();
+		expect(colBox.y).toBeGreaterThan(advBox.y);
+
+		// click Colored Bookmark — critical: dropdown must NOT auto-close
+		await coloredRow.click();
+
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible({ timeout: 5000 });
+
+		// dropdown container still visible (menu itself)
+		await expect(page.getByText('8 colors')).toBeVisible();
+		// verify Advanced Play is hidden (submenu replaced it) but dropdown is still open (Back visible)
+		await expect(page.getByRole('button', { name: /Back to verse options/ })).toBeVisible();
+		// submenu grid not empty
+		await expect(page.getByRole('menuitemradio')).toHaveCount(8);
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC01_menu_stays_open_light.png`, fullPage: false });
+		// also ensure no console errors (except benign)
+		const errors = (page._consoleLogs || []).filter((l) => l.includes('[error]') && !l.includes('Failed to load'));
+		expect(errors).toEqual([]);
+	});
+
+	test('TC02 menu stays open — dark theme (theme 5)', async ({ page }) => {
+		await setWebsiteTheme(page, 5);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+
+		const coloredRow = page.getByRole('menuitem', { name: /Colored Bookmark/ });
+		await expect(coloredRow).toBeVisible();
+		await coloredRow.click();
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible({ timeout: 5000 });
+		await expect(page.getByText('8 colors')).toBeVisible();
+		await expect(page.getByRole('menuitemradio')).toHaveCount(8);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC02_menu_stays_open_dark.png`, fullPage: false });
+	});
+
+	test('TC03 submenu 4x2 grid layout correct', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible();
+		await expect(page.getByText('8 colors')).toBeVisible();
+
+		const swatches = page.getByRole('menuitemradio');
+		await expect(swatches).toHaveCount(8);
+
+		// check grid class
+		const grid = page.locator('.grid.grid-cols-4.gap-2');
+		await expect(grid).toBeVisible();
+		// check aria attributes
+		for (let i = 1; i <= 8; i++) {
+			const names = ['Amber Glow', 'Terracotta Dune', 'Rose Ash', 'Lavender Mist', 'Powder Slate', 'Sage Teal', 'Olive Sage', 'Stone Taupe'];
+			const sw = page.getByRole('menuitemradio', { name: new RegExp(names[i - 1]) });
+			await expect(sw).toHaveAttribute('aria-label', new RegExp(names[i - 1]));
+			await expect(sw).toHaveAttribute('role', 'menuitemradio');
+		}
+		// w-7 h-7 = 28px
+		const firstBox = await swatches.first().boundingBox();
+		expect(firstBox.width).toBeGreaterThanOrEqual(26);
+		expect(firstBox.width).toBeLessThanOrEqual(32);
+		expect(firstBox.height).toBeGreaterThanOrEqual(26);
+		// submenu width w-56 (224) or md:w-64 (256)
+		const subBox = await submenu.boundingBox();
+		expect(subBox.width).toBeGreaterThanOrEqual(200);
+		expect(subBox.width).toBeLessThanOrEqual(320);
+
+		// Clear disabled when no color
+		const clearBtn = page.getByRole('menuitem', { name: 'Clear color' });
+		await expect(clearBtn).toBeVisible();
+		await expect(clearBtn).toBeDisabled();
+		await expect(clearBtn).toHaveAttribute('aria-disabled', 'true');
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC03_grid_4x2.png`, fullPage: false });
+	});
+
+	test('TC04 Back returns to main menu, dropdown stays open', async ({ page }) => {
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible();
+		const backBtn = page.getByRole('button', { name: /Back to verse options/ });
+		await expect(backBtn).toBeVisible();
+		await backBtn.click();
+		// submenu hidden, main menu visible, dropdown still open
+		await expect(submenu).toBeHidden();
+		await expect(page.getByRole('menuitem', { name: /Colored Bookmark/ })).toBeVisible();
+		await expect(page.getByText('Advanced Play')).toBeVisible();
+		// trigger focus? check at least dropdownOpen still true (Back not closing dropdown)
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC04_back_returns.png`, fullPage: false });
+	});
+
+	test('TC05 Escape from submenu returns to main menu (not close dropdown)', async ({ page }) => {
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const submenu = page.getByRole('menu', { name: 'Bookmark colors' });
+		await expect(submenu).toBeVisible();
+		await page.keyboard.press('Escape');
+		await expect(submenu).toBeHidden({ timeout: 3000 });
+		await expect(page.getByRole('menuitem', { name: /Colored Bookmark/ })).toBeVisible();
+		await expect(page.getByText('Advanced Play')).toBeVisible();
+		// second Escape should close dropdown (outside test scope, but verify not crash)
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC05_escape.png`, fullPage: false });
+	});
+
+	test('TC06 swatch select tints verse, persists reload, selected ring', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+
+		const amber = page.getByRole('menuitemradio', { name: /Amber Glow/ });
+		await expect(amber).toBeVisible();
+		await amber.click();
+
+		// dropdown should close
+		await expect(page.getByRole('menu', { name: 'Bookmark colors' })).toBeHidden({ timeout: 3000 }).catch(() => {});
+		// verse wrapper tint: light theme 1 => bg-[#EADDB8]/14
+		const verse = page.locator('[id="2:255"]');
+		await expect(verse).toBeVisible({ timeout: 8000 });
+		await expect(verse).toHaveClass(/bg-\[#EADDB8\]/);
+		// also check rounded-xl for block mode
+		await expect(verse).toHaveClass(/rounded-xl/);
+
+		const stored = await page.evaluate(() => {
+			try {
+				return JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks;
+			} catch {
+				return null;
+			}
+		});
+		expect(stored['2:255']).toBe(1);
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC06_tint_after_select.png`, fullPage: false });
+
+		// reload persists
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const verseReloaded = page.locator('[id="2:255"]');
+		await expect(verseReloaded).toHaveClass(/bg-\[#EADDB8\]/);
+
+		// reopen submenu → selected ring & checkmark
+		await page.locator('#verse-options-255').first().click().catch(async () => {
+			await page.goto('/2?startVerse=255', { waitUntil: 'domcontentloaded' });
+			await page.waitForSelector('#verse-options-255');
+			await page.locator('#verse-options-255').first().click();
+		});
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const amberAfter = page.getByRole('menuitemradio', { name: /Amber Glow/ });
+		await expect(amberAfter).toHaveAttribute('aria-checked', 'true');
+		// ring-2 class when selected
+		await expect(amberAfter).toHaveClass(/ring-2/);
+		await expect(amberAfter.locator('text=✓')).toBeVisible();
+		// trailing dot visible in main row (after back)
+		await page.getByRole('button', { name: /Back to verse options/ }).click();
+		await expect(page.getByRole('menuitem', { name: /Colored Bookmark/ })).toBeVisible();
+	});
+
+	test('TC06b swatch select dark theme uses darkHex #B9973F/18', async ({ page }) => {
+		await setWebsiteTheme(page, 5);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		await page.getByRole('menuitemradio', { name: /Amber Glow/ }).click();
+		const verse = page.locator('[id="2:255"]');
+		await expect(verse).toBeVisible({ timeout: 8000 });
+		await expect(verse).toHaveClass(/bg-\[#B9973F\]/);
+		await expect(verse).toHaveClass(/\/18/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC06b_dark_tint.png`, fullPage: false });
+	});
+
+	test('TC07 Clear removes tint and persists, enabled only when colored', async ({ page }) => {
+		// seed a color first
+		await setWebsiteTheme(page, 1);
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		await page.getByRole('menuitemradio', { name: /Amber Glow/ }).click();
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/bg-\[#/);
+
+		// reopen and clear
+		await page.waitForTimeout(500);
+		await page.locator('#verse-options-255').first().click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		const clearBtn = page.getByRole('menuitem', { name: 'Clear color' });
+		await expect(clearBtn).toBeEnabled();
+		await clearBtn.click();
+		await expect(page.locator('[id="2:255"]')).not.toHaveClass(/bg-\[#/, { timeout: 8000 });
+		const cleared = await page.evaluate(() => {
+			try {
+				return JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks['2:255'];
+			} catch {
+				return 'error';
+			}
+		});
+		expect(cleared).toBeUndefined();
+		// bookmarks dual-track intact
+		const bookmarks = await page.evaluate(() => {
+			try {
+				return JSON.parse(localStorage.getItem('userSettings')).userBookmarks;
+			} catch {
+				return null;
+			}
+		});
+		expect(Array.isArray(bookmarks)).toBeTruthy();
+
+		// reload → still cleared
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 }).catch(() => {});
+		await expect(page.locator('[id="2:255"]')).not.toHaveClass(/bg-\[#/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC07_clear_removed.png`, fullPage: false });
+
+		// reopen submenu → Clear now disabled
+		await page.locator('#verse-options-255').first().click().catch(() => {});
+		await page.waitForTimeout(300);
+		if (await page.getByRole('menuitem', { name: /Colored Bookmark/ }).isVisible().catch(() => false)) {
+			await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+			await expect(page.getByRole('menuitem', { name: 'Clear color' })).toBeDisabled();
+		}
+	});
+
+	test('TC08 grouping still works homepage Colored tab', async ({ page }) => {
+		await page.evaluate(() => {
+			try {
+				const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+				raw.userColoredBookmarks = { '1:1': 1, '2:255': 1, '36:58': 4, '114:6': 8 };
+				localStorage.setItem('userSettings', JSON.stringify(raw));
+			} catch {}
+		});
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await expect(coloredTab).toBeVisible();
+		await coloredTab.click();
+		await expect(coloredTab).toContainText('(4)');
+		const panel = page.locator('#colored-tab-panel');
+		await expect(panel).toBeVisible();
+		await expect(page.locator('#colored-section-1')).toContainText('Amber Glow');
+		await expect(page.locator('#colored-section-1')).toContainText('(2)');
+		await expect(page.locator('#colored-section-4')).toContainText('Lavender Mist');
+		await expect(page.locator('#colored-section-8')).toContainText('(1)');
+		await expect(page.getByText('No verses in Terracotta Dune')).toBeVisible();
+		await expect(page.locator('#colored-section-2').locator('..')).toHaveClass(/opacity-40/);
+		const link = panel.locator('a[href*="?startVerse="]').first();
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute('href', /\/\d+\?startVerse=\d+/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC08_grouping.png`, fullPage: true });
+	});
+
+	test('TC08b global empty state when no colored bookmarks', async ({ page }) => {
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await coloredTab.click();
+		await expect(page.getByText(/No colored bookmarks yet/)).toBeVisible();
+		await expect(coloredTab).not.toContainText('(');
+	});
+
+	test('TC09 switch swatch replaces color (Lavender Mist)', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await gotoChapterVerse(page, 2, 255);
+		await openVerseDropdown(page, 255);
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		await page.getByRole('menuitemradio', { name: /Amber Glow/ }).evaluate((el) => el.click()).catch(async () => {
+			await page.getByRole('menuitemradio', { name: /Amber Glow/ }).click({ force: true });
+		});
+		await page.waitForTimeout(400);
+		await page.locator('#verse-options-255').first().click();
+		await page.getByRole('menuitem', { name: /Colored Bookmark/ }).click();
+		await page.getByRole('menuitemradio', { name: /Lavender Mist/ }).evaluate((el) => el.click()).catch(async () => {
+			await page.getByRole('menuitemradio', { name: /Lavender Mist/ }).click({ force: true });
+		});
+		const updated = await page.evaluate(() => {
+			try {
+				return JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks['2:255'];
+			} catch {
+				return null;
+			}
+		});
+		expect(updated).toBe(4);
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/bg-\[#DDD4E8\]/);
+	});
+
+	test('TC10 tint persists via direct storage injection (bypass menu) light+dark', async ({ page }) => {
+		// light theme
+		await setWebsiteTheme(page, 1);
+		await page.evaluate(() => {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			raw.userColoredBookmarks = { '2:255': 1 };
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		});
+		await page.goto('/2?startVerse=255', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/bg-\[#EADDB8\]/);
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/rounded-xl/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC10_tint_light_injected.png`, fullPage: false });
+
+		// dark theme
+		await setWebsiteTheme(page, 5);
+		await page.evaluate(() => {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			raw.userColoredBookmarks = { '2:255': 1 };
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/bg-\[#B9973F\]/);
+		await expect(page.locator('[id="2:255"]')).toHaveClass(/\/18/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC10_tint_dark_injected.png`, fullPage: false });
+
+		// clear via storage
+		await page.evaluate(() => {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			delete raw.userColoredBookmarks['2:255'];
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		await expect(page.locator('[id="2:255"]')).not.toHaveClass(/bg-\[#/);
+	});
+});

--- a/tests/e2e/test-004-fix-verification.e2e.spec.js
+++ b/tests/e2e/test-004-fix-verification.e2e.spec.js
@@ -1,0 +1,507 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * TEST-004 Verification: FIX-004
+ * (1) Verse background tint now uses inline rgba (background-color: rgba(r,g,b,opacity)) and is visible — check computedStyle backgroundColor for light rgba(234,221,184,0.14) and dark rgba(185,151,63,0.18) on verse id 2:255, plus rounded tint and persistence across reload and theme switch; ensure not using Tailwind bg class for background.
+ * (2) Per-color collapsible menus — homepage Colored tab shows 8 headers each as button[aria-expanded][aria-controls], clicking expands only that color's panel (role=region hidden/block), empty shows placeholder when expanded, counts correct, keyboard Enter/Space toggles, state persists in localStorage, global empty still handled.
+ * Desktop chromium + mobile Pixel5, light/dark. Capture screenshots, console/network logs, build grep logs.
+ */
+
+const EVIDENCE_DIR = 'test-results/test-004-evidence';
+const SCREENSHOT_DIR = 'test-results/test-004-screenshots';
+
+function ensureDirs() {
+	for (const d of [EVIDENCE_DIR, SCREENSHOT_DIR]) {
+		if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+	}
+}
+
+async function setWebsiteTheme(page, themeId) {
+	await page.evaluate((t) => {
+		try {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			if (!raw.displaySettings) raw.displaySettings = {};
+			raw.displaySettings.websiteTheme = t;
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		} catch {}
+		try {
+			document.documentElement.setAttribute('data-theme', String(t));
+		} catch {}
+	}, themeId);
+}
+
+async function seedColoredBookmarks(page, map) {
+	await page.evaluate((m) => {
+		const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+		raw.userColoredBookmarks = m;
+		localStorage.setItem('userSettings', JSON.stringify(raw));
+	}, map);
+}
+
+async function getVerseTintInfo(page, verseId = '2:255') {
+	return await page.evaluate((vid) => {
+		const el = document.getElementById(vid);
+		if (!el) return null;
+		const cs = getComputedStyle(el);
+		return {
+			backgroundColor: cs.backgroundColor,
+			borderRadius: cs.borderRadius,
+			className: el.className,
+			styleAttr: el.getAttribute('style') || '',
+			inlineBg: el.style.backgroundColor
+		};
+	}, verseId);
+}
+
+async function gotoChapterVerse(page, chapter = 2, verse = 255) {
+	await page.goto(`/${chapter}?startVerse=${verse}`, { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+	await page.waitForSelector(`[id="2:255"]`, { timeout: 15000 });
+	await page.waitForTimeout(400);
+}
+
+async function gotoHomeColoredTab(page) {
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page.waitForTimeout(800);
+	const coloredTab = page.getByRole('tab', { name: /Colored/ });
+	await expect(coloredTab).toBeVisible({ timeout: 8000 });
+	await coloredTab.click();
+	await expect(page.locator('#colored-tab-panel')).toBeVisible();
+	await page.waitForTimeout(800);
+	// ensure accordion headers rendered and hydration complete
+	await page.waitForSelector('button[id^="colored-section-"]', { timeout: 8000 });
+	await page.waitForTimeout(1000);
+}
+
+async function clickAccordion(page, id) {
+	const sel = `#colored-section-${id}`;
+	await page.waitForSelector(sel, { timeout: 5000 });
+	const btn = page.locator(sel);
+	await btn.scrollIntoViewIfNeeded().catch(() => {});
+	const before = await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.getAttribute('aria-expanded'), id);
+	// try Playwright click, fallback to evaluate
+	try {
+		await btn.click({ force: true, timeout: 3000 });
+	} catch {
+		await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.click(), id);
+	}
+	await page.waitForTimeout(800);
+	// debug: log aria-expanded after click
+	const after = await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.getAttribute('aria-expanded'), id);
+	// if value unchanged, try evaluate click again (handles focus/transition race)
+	if (after === before) {
+		await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.click(), id);
+		await page.waitForTimeout(800);
+	}
+}
+
+test.describe('TEST-004 FIX-004: inline rgba tint + per-color collapsible accordion @critical', () => {
+	test.beforeAll(() => ensureDirs());
+
+	test.beforeEach(async ({ page }) => {
+		page._consoleLogs = [];
+		page._networkLogs = [];
+		page.on('console', (msg) => {
+			const entry = `[${msg.type()}] ${msg.text()}`;
+			page._consoleLogs.push(entry);
+		});
+		page.on('request', (req) => page._networkLogs.push(`REQ ${req.method()} ${req.url()}`));
+		page.on('response', (res) => page._networkLogs.push(`RES ${res.status()} ${res.url().slice(0, 140)}`));
+		page.on('pageerror', (err) => page._consoleLogs.push(`[pageerror] ${err.message}`));
+
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		// clear both storages
+		await page.evaluate(() => {
+			try { localStorage.clear(); } catch {}
+			try { localStorage.removeItem('coloredBookmarksAccordionExpanded'); } catch {}
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+	});
+
+	test.afterEach(async ({ page }, testInfo) => {
+		const safeTitle = testInfo.title.replace(/[^a-z0-9]+/gi, '_').slice(0, 80);
+		const project = testInfo.project.name;
+		const base = `${EVIDENCE_DIR}/${project}_${safeTitle}`;
+		try {
+			fs.writeFileSync(`${base}.console.log`, (page._consoleLogs || []).join('\n') || '(no console)');
+			fs.writeFileSync(`${base}.network.log`, (page._networkLogs || []).join('\n').slice(0, 25000) || '(no network)');
+		} catch {}
+		if (testInfo.status !== testInfo.expectedStatus) {
+			await page.screenshot({ path: `${SCREENSHOT_DIR}/${project}_${safeTitle}_FAILURE.png`, fullPage: true }).catch(() => {});
+		}
+	});
+
+	// ---- 1. Verse tint inline rgba ----
+
+	test('TC01 verse tint light rgba visible, rounded, no Tailwind bg class (light theme)', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info).not.toBeNull();
+		// light amber glow: #EADDB8 opacity 0.14 -> rgba(234,221,184,0.14)
+		// computedStyle adds spaces: rgba(234, 221, 184, 0.14)
+		expect(info.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.14\)/);
+		expect(info.styleAttr).toContain('rgba(234,221,184,0.14)');
+		expect(info.styleAttr).toContain('background-color');
+		// not using Tailwind bg class
+		expect(info.className).not.toMatch(/bg-\[#/);
+		expect(info.className).not.toContain('bg-[#EADDB8]');
+		// rounded tint
+		expect(info.className).toContain('rounded-xl');
+		expect(info.className).toContain('transition-colors');
+		// borderRadius visible
+		expect(info.borderRadius).not.toBe('0px');
+		// inline style present
+		expect(info.inlineBg).toMatch(/rgba/);
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC01_tint_light.png` });
+		const errors = (page._consoleLogs || []).filter((l) => l.includes('[error]') && !l.includes('Failed to load'));
+		expect(errors).toEqual([]);
+	});
+
+	test('TC02 verse tint dark rgba visible, rounded, no Tailwind bg class (dark theme)', async ({ page }) => {
+		await setWebsiteTheme(page, 5);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		// need reload after theme change to rehydrate stores
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info).not.toBeNull();
+		// dark amber: #B9973F opacity 0.18 -> rgba(185,151,63,0.18)
+		expect(info.backgroundColor).toMatch(/rgba\(185,\s*151,\s*63,\s*0\.18\)/);
+		expect(info.styleAttr).toContain('rgba(185,151,63,0.18)');
+		expect(info.className).not.toMatch(/bg-\[#/);
+		expect(info.className).toContain('rounded-xl');
+		expect(info.borderRadius).not.toBe('0px');
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC02_tint_dark.png` });
+	});
+
+	test('TC03 verse tint persists across reload (light)', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const before = await getVerseTintInfo(page, '2:255');
+		expect(before.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.14\)/);
+
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const after = await getVerseTintInfo(page, '2:255');
+		expect(after.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.14\)/);
+		expect(after.styleAttr).toContain('rgba(234,221,184,0.14)');
+		expect(after.className).not.toMatch(/bg-\[#/);
+
+		// verify localStorage still has it
+		const stored = await page.evaluate(() => {
+			try { return JSON.parse(localStorage.getItem('userSettings')).userColoredBookmarks['2:255']; } catch { return null; }
+		});
+		expect(stored).toBe(1);
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC03_tint_persist_reload.png` });
+	});
+
+	test('TC04 verse tint theme switch recomputes rgba light->dark', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const light = await getVerseTintInfo(page, '2:255');
+		expect(light.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.14\)/);
+
+		// switch to dark
+		await setWebsiteTheme(page, 5);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const dark = await getVerseTintInfo(page, '2:255');
+		expect(dark.backgroundColor).toMatch(/rgba\(185,\s*151,\s*63,\s*0\.18\)/);
+		expect(dark.styleAttr).toContain('rgba(185,151,63,0.18)');
+		expect(dark.className).not.toMatch(/bg-\[#/);
+
+		// switch back to light
+		await setWebsiteTheme(page, 1);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const light2 = await getVerseTintInfo(page, '2:255');
+		expect(light2.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.14\)/);
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC04_tint_theme_switch.png` });
+	});
+
+	test('TC04b verse without color has no inline background', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, {});
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info).not.toBeNull();
+		// no rgba
+		expect(info.styleAttr).not.toContain('rgba');
+		// transparent background (rgba 0,0,0,0 or empty)
+		expect(info.backgroundColor).toMatch(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+		expect(info.className).not.toMatch(/bg-\[#/);
+	});
+
+	// ---- 2. Per-color collapsible menus ----
+
+	test('TC05 homepage Colored tab shows 8 headers each as button[aria-expanded][aria-controls]', async ({ page }) => {
+		// seed with some data to check counts, but headers should exist even when empty — test both
+		await seedColoredBookmarks(page, { '1:1': 1, '2:255': 1, '36:58': 4, '114:6': 8 });
+		await gotoHomeColoredTab(page);
+
+		// 8 headers
+		const headers = page.locator('button[id^="colored-section-"]');
+		await expect(headers).toHaveCount(8);
+
+		for (let id = 1; id <= 8; id++) {
+			const btn = page.locator(`#colored-section-${id}`);
+			await expect(btn).toBeVisible();
+			await expect(btn).toHaveAttribute('aria-expanded', /true|false/);
+			await expect(btn).toHaveAttribute('aria-controls', `colored-panel-${id}`);
+			// ensure tag is button
+			await expect(btn).toHaveJSProperty('tagName', 'BUTTON');
+
+			const panel = page.locator(`#colored-panel-${id}`);
+			await expect(panel).toHaveAttribute('role', 'region');
+			await expect(panel).toHaveAttribute('aria-labelledby', `colored-section-${id}`);
+		}
+
+		// counts: Amber Glow (1) should have (2), Lavender (4) (1), Stone Taupe (8) (1), others 0
+		await expect(page.locator('#colored-section-1')).toContainText('(2)');
+		await expect(page.locator('#colored-section-4')).toContainText('(1)');
+		await expect(page.locator('#colored-section-8')).toContainText('(1)');
+		await expect(page.locator('#colored-section-2')).toContainText('(0)');
+
+		// panels hidden initially (all collapsed default {})
+		for (let id = 1; id <= 8; id++) {
+			await expect(page.locator(`#colored-panel-${id}`)).toHaveClass(/hidden/);
+			// not visible when hidden
+			await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+		}
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC05_8_headers_collapsed.png`, fullPage: true });
+	});
+
+	test('TC06 clicking expands only that color panel, others stay collapsed, placeholder hidden until expanded', async ({ page }) => {
+		await seedColoredBookmarks(page, { '1:1': 1, '2:255': 1, '36:58': 4 });
+		await gotoHomeColoredTab(page);
+
+		// initially all hidden
+		for (let id = 1; id <= 8; id++) await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+
+		// click Amber Glow (id 1)
+		await clickAccordion(page, 1);
+		const btn1 = page.locator('#colored-section-1');
+		await expect(btn1).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-1')).toHaveClass(/block/);
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+		// others stay hidden
+		for (let id = 2; id <= 8; id++) {
+			await expect(page.locator(`#colored-section-${id}`)).toHaveAttribute('aria-expanded', 'false');
+			await expect(page.locator(`#colored-panel-${id}`)).toHaveClass(/hidden/);
+			await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+		}
+		// Amber panel should have cards (2)
+		const amberCards = page.locator('#colored-panel-1 a[href*="?startVerse="]');
+		await expect(amberCards).toHaveCount(2);
+
+		// Empty color (id 2) still hidden — placeholder not visible when collapsed
+		await expect(page.locator('#colored-panel-2')).toBeHidden();
+		const emptyPlaceholderInsideHidden = page.locator('#colored-panel-2').getByText('No verses in Terracotta Dune');
+		// hidden panel's placeholder is not visible (hidden parent)
+		await expect(emptyPlaceholderInsideHidden).toBeHidden();
+
+		// expand empty color 2
+		await clickAccordion(page, 2);
+		const btn2 = page.locator('#colored-section-2');
+		await expect(btn2).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-2')).toHaveClass(/block/);
+		await expect(page.locator('#colored-panel-2')).toBeVisible();
+		// placeholder now visible
+		await expect(page.locator('#colored-panel-2').getByText('No verses in Terracotta Dune')).toBeVisible();
+		// check placeholder opacity classes (opacity-40)
+		const placeholder = page.locator('#colored-panel-2').getByText('No verses in Terracotta Dune');
+		await expect(placeholder).toHaveClass(/opacity-40/);
+
+		// Amber still expanded (independence)
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+		await expect(btn1).toHaveAttribute('aria-expanded', 'true');
+
+		// clicking again collapses
+		await clickAccordion(page, 1);
+		await expect(btn1).toHaveAttribute('aria-expanded', 'false');
+		await expect(page.locator('#colored-panel-1')).toHaveClass(/hidden/);
+		await expect(page.locator('#colored-panel-1')).toBeHidden();
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC06_expand_only_one.png`, fullPage: true });
+	});
+
+	test('TC07 keyboard Enter/Space toggles, focus visible', async ({ page }) => {
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoHomeColoredTab(page);
+
+		const btn1 = page.locator('#colored-section-1');
+		await btn1.scrollIntoViewIfNeeded();
+		await btn1.focus();
+		await expect(btn1).toBeFocused();
+
+		// Enter should toggle — use element press for reliability
+		await btn1.press('Enter');
+		await page.waitForTimeout(400);
+		await expect(btn1).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+
+		await btn1.press('Enter');
+		await page.waitForTimeout(400);
+		await expect(btn1).toHaveAttribute('aria-expanded', 'false');
+		await expect(page.locator('#colored-panel-1')).toBeHidden();
+
+		// Space should toggle
+		await btn1.focus();
+		await btn1.press(' ');
+		await page.waitForTimeout(400);
+		await expect(btn1).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+
+		await btn1.press(' ');
+		await page.waitForTimeout(400);
+		await expect(btn1).toHaveAttribute('aria-expanded', 'false');
+		await expect(page.locator('#colored-panel-1')).toBeHidden();
+
+		// Tab cycles through 8 headers
+		await btn1.focus();
+		for (let i = 1; i < 8; i++) {
+			await page.keyboard.press('Tab');
+			await page.waitForTimeout(100);
+			const nextBtn = page.locator(`#colored-section-${i + 1}`);
+			await expect(nextBtn).toBeFocused();
+		}
+	});
+
+	test('TC08 state persists in localStorage across reload', async ({ page }) => {
+		await seedColoredBookmarks(page, { '1:1': 1, '2:255': 1 });
+		await gotoHomeColoredTab(page);
+
+		// expand 1 and 4
+		await clickAccordion(page, 1);
+		await clickAccordion(page, 4);
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+		await expect(page.locator('#colored-panel-4')).toBeVisible();
+
+		// check localStorage
+		const stored = await page.evaluate(() => {
+			try { return JSON.parse(localStorage.getItem('coloredBookmarksAccordionExpanded')); } catch { return null; }
+		});
+		expect(stored).toEqual(expect.objectContaining({ '1': true, '4': true }));
+
+		// reload — keep colored tab active via homepageLayoutPreferences or re-click
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+		// ensure we are on home and colored tab visible; click if not active
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await coloredTab.click().catch(() => {});
+		await page.waitForTimeout(500);
+		await expect(page.locator('#colored-tab-panel')).toBeVisible();
+		await page.waitForSelector('button[id^="colored-section-"]');
+		await page.waitForTimeout(500);
+		// After reload, expanded state should be restored
+		await expect(page.locator('#colored-panel-1')).toBeVisible({ timeout: 8000 });
+		await expect(page.locator('#colored-section-1')).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-4')).toBeVisible();
+		// others still hidden
+		await expect(page.locator('#colored-panel-2')).toBeHidden();
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC08_persist_localStorage.png`, fullPage: true });
+	});
+
+	test('TC09 counts correct per color, canonical order preserved', async ({ page }) => {
+		await seedColoredBookmarks(page, { '36:58': 4, '2:255': 1, '1:1': 1, '114:6': 1, '2:10': 1 });
+		await gotoHomeColoredTab(page);
+
+		// total badge
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await expect(coloredTab).toContainText('(5)');
+
+		// per color
+		await expect(page.locator('#colored-section-1')).toContainText('(4)');
+		await expect(page.locator('#colored-section-4')).toContainText('(1)');
+		await expect(page.locator('#colored-section-8')).toContainText('(0)');
+
+		// expand Amber and check canonical order: 1:1, 2:10, 2:255, 114:6 (chapter*1000+verse)
+		await clickAccordion(page, 1);
+		const links = page.locator('#colored-panel-1 a[href*="?startVerse="]');
+		await expect(links).toHaveCount(4);
+		const hrefs = await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')));
+		// canonical: 1:1 -> /1?startVerse=1, 2:10 -> /2?startVerse=10, 2:255 -> /2?startVerse=255, 114:6 -> /114?startVerse=6
+		expect(hrefs[0]).toMatch(/\/1\?startVerse=1/);
+		expect(hrefs[1]).toMatch(/\/2\?startVerse=10/);
+		expect(hrefs[2]).toMatch(/\/2\?startVerse=255/);
+		expect(hrefs[3]).toMatch(/\/114\?startVerse=6/);
+	});
+
+	test('TC10 global empty still handled with 8 headers always rendered', async ({ page }) => {
+		await seedColoredBookmarks(page, {});
+		// ensure localStorage accordion cleared
+		await page.evaluate(() => { try { localStorage.removeItem('coloredBookmarksAccordionExpanded'); } catch {} });
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+
+		await gotoHomeColoredTab(page);
+
+		// global empty message
+		await expect(page.getByText(/No colored bookmarks yet/)).toBeVisible();
+		await expect(page.getByText(/Colored Bookmark to tint/)).toBeVisible();
+		await expect(page.locator('#colored-tab-panel').getByRole('status')).toBeVisible();
+
+		// badge hidden when zero (no parentheses)
+		const coloredTab = page.getByRole('tab', { name: /Colored/ });
+		await expect(coloredTab).not.toContainText('(');
+
+		// 8 headers still visible
+		const headers = page.locator('button[id^="colored-section-"]');
+		await expect(headers).toHaveCount(8);
+		for (let id = 1; id <= 8; id++) {
+			await expect(page.locator(`#colored-section-${id}`)).toBeVisible();
+			await expect(page.locator(`#colored-section-${id}`)).toContainText('(0)');
+			await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+		}
+
+		// expand one empty shows placeholder
+		await clickAccordion(page, 3);
+		await expect(page.locator('#colored-panel-3')).toBeVisible();
+		await expect(page.locator('#colored-panel-3').getByText('No verses in Rose Ash')).toBeVisible();
+		await expect(page.locator('#colored-panel-3').getByText('No verses in Rose Ash')).toHaveClass(/opacity-40/);
+
+		// collapse again hides placeholder (hidden parent)
+		await clickAccordion(page, 3);
+		await expect(page.locator('#colored-panel-3')).toBeHidden();
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${page.context.name ?? 'chromium'}_TC10_global_empty.png`, fullPage: true });
+	});
+
+	test('TC11 chevron rotates on expand, header sticky and rounded', async ({ page }) => {
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoHomeColoredTab(page);
+
+		const btn = page.locator('#colored-section-1');
+		const chevron = btn.locator('svg');
+		await expect(chevron).toBeVisible();
+		// initially no rotate-180
+		await expect(chevron).not.toHaveClass(/rotate-180/);
+
+		await clickAccordion(page, 1);
+		await expect(chevron).toHaveClass(/rotate-180/);
+		// header has sticky and rounded
+		await expect(btn).toHaveClass(/sticky/);
+		await expect(btn).toHaveClass(/rounded-lg/);
+
+		await clickAccordion(page, 1);
+		await expect(chevron).not.toHaveClass(/rotate-180/);
+	});
+});

--- a/tests/e2e/test-006-fix-verification.e2e.spec.js
+++ b/tests/e2e/test-006-fix-verification.e2e.spec.js
@@ -1,0 +1,331 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * TEST-006 Verification: FIX-006 opacity bump light 0.22-0.28 / dark 0.30-0.34
+ * - Unit opacities updated (bg-[#hex]/pct and rgba)
+ * - Playwright computedStyle shows new rgba visibly stronger but still pastel alpha <0.4
+ * - Tailwind/browserslist 0 warnings (checked via build log)
+ * - Grouping/accordion still works
+ * - Screenshots for light/dark tint evidence
+ */
+
+const EVIDENCE_DIR = 'test-results/test-006-evidence';
+const SCREENSHOT_DIR = 'test-results/test-006-screenshots';
+
+function ensureDirs() {
+	for (const d of [EVIDENCE_DIR, SCREENSHOT_DIR]) {
+		if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+	}
+}
+
+async function setWebsiteTheme(page, themeId) {
+	await page.evaluate((t) => {
+		try {
+			const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+			if (!raw.displaySettings) raw.displaySettings = {};
+			raw.displaySettings.websiteTheme = t;
+			localStorage.setItem('userSettings', JSON.stringify(raw));
+		} catch {}
+		try { document.documentElement.setAttribute('data-theme', String(t)); } catch {}
+	}, themeId);
+}
+
+async function seedColoredBookmarks(page, map) {
+	await page.evaluate((m) => {
+		const raw = JSON.parse(localStorage.getItem('userSettings') || '{}');
+		raw.userColoredBookmarks = m;
+		localStorage.setItem('userSettings', JSON.stringify(raw));
+	}, map);
+}
+
+async function getVerseTintInfo(page, verseId = '2:255') {
+	return await page.evaluate((vid) => {
+		const el = document.getElementById(vid);
+		if (!el) return null;
+		const cs = getComputedStyle(el);
+		return {
+			backgroundColor: cs.backgroundColor,
+			borderRadius: cs.borderRadius,
+			className: el.className,
+			styleAttr: el.getAttribute('style') || '',
+			inlineBg: el.style.backgroundColor
+		};
+	}, verseId);
+}
+
+async function gotoChapterVerse(page, chapter = 2, verse = 255) {
+	await page.goto(`/${chapter}?startVerse=${verse}`, { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+	await page.waitForSelector(`[id="2:255"]`, { timeout: 15000 });
+	await page.waitForTimeout(500);
+}
+
+async function gotoHomeColoredTab(page) {
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page.waitForTimeout(800);
+	const coloredTab = page.getByRole('tab', { name: /Colored/ });
+	await expect(coloredTab).toBeVisible({ timeout: 8000 });
+	await coloredTab.click();
+	await expect(page.locator('#colored-tab-panel')).toBeVisible();
+	await page.waitForTimeout(800);
+	await page.waitForSelector('button[id^="colored-section-"]', { timeout: 8000 });
+	await page.waitForTimeout(500);
+}
+
+async function clickAccordion(page, id) {
+	const sel = `#colored-section-${id}`;
+	await page.waitForSelector(sel, { timeout: 5000 });
+	const btn = page.locator(sel);
+	await btn.scrollIntoViewIfNeeded().catch(() => {});
+	const before = await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.getAttribute('aria-expanded'), id);
+	try { await btn.click({ force: true, timeout: 3000 }); } catch { await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.click(), id); }
+	await page.waitForTimeout(800);
+	const after = await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.getAttribute('aria-expanded'), id);
+	if (after === before) {
+		await page.evaluate((i) => document.getElementById(`colored-section-${i}`)?.click(), id);
+		await page.waitForTimeout(800);
+	}
+}
+
+test.describe('TEST-006 FIX-006: bumped opacity light 0.22-0.28 dark 0.30-0.34 @critical', () => {
+	test.beforeAll(() => ensureDirs());
+
+	test.beforeEach(async ({ page }) => {
+		page._consoleLogs = [];
+		page._networkLogs = [];
+		page.on('console', (msg) => page._consoleLogs.push(`[${msg.type()}] ${msg.text()}`));
+		page.on('request', (req) => page._networkLogs.push(`REQ ${req.method()} ${req.url()}`));
+		page.on('response', (res) => page._networkLogs.push(`RES ${res.status()} ${res.url().slice(0,140)}`));
+		page.on('pageerror', (err) => page._consoleLogs.push(`[pageerror] ${err.message}`));
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		await page.evaluate(() => {
+			try { localStorage.clear(); } catch {}
+			try { localStorage.removeItem('coloredBookmarksAccordionExpanded'); } catch {}
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(() => {});
+	});
+
+	test.afterEach(async ({ page }, testInfo) => {
+		const safeTitle = testInfo.title.replace(/[^a-z0-9]+/gi, '_').slice(0,80);
+		const project = testInfo.project.name;
+		const base = `${EVIDENCE_DIR}/${project}_${safeTitle}`;
+		try {
+			fs.writeFileSync(`${base}.console.log`, (page._consoleLogs || []).join('\n') || '(no console)');
+			fs.writeFileSync(`${base}.network.log`, (page._networkLogs || []).join('\n').slice(0,25000) || '(no network)');
+		} catch {}
+		if (testInfo.status !== testInfo.expectedStatus) {
+			await page.screenshot({ path: `${SCREENSHOT_DIR}/${project}_${safeTitle}_FAILURE.png`, fullPage: true }).catch(()=>{});
+		}
+	});
+
+	test('TC01 light tint new rgba 0.28 visible stronger pastel and computedStyle matches FIX-006', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info).not.toBeNull();
+		// FIX-006: id1 light 0.28 -> rgba(234,221,184,0.28)
+		expect(info.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.28\)/);
+		expect(info.styleAttr).toContain('rgba(234,221,184,0.28)');
+		expect(info.styleAttr).toContain('background-color');
+		// pastel aesthetic: alpha <0.4 not harsh, translucent not solid
+		const alpha = parseFloat(info.backgroundColor.match(/rgba\(.*,\s*([0-9.]+)\)/)?.[1] || '0');
+		expect(alpha).toBeGreaterThan(0.18);
+		expect(alpha).toBeLessThan(0.4);
+		// not using purged Tailwind bg class for actual tint
+		expect(info.className).not.toMatch(/bg-\[#EADDB8\]/);
+		expect(info.className).toContain('rounded-xl');
+		expect(info.className).toContain('transition-colors');
+		expect(info.borderRadius).not.toBe('0px');
+		// also verify other ids light opacities
+		await page.evaluate(() => {
+			try {
+				const raw = JSON.parse(localStorage.getItem('userSettings')||'{}');
+				raw.userColoredBookmarks = { '2:10': 8, '3:1': 3 };
+				localStorage.setItem('userSettings', JSON.stringify(raw));
+			} catch {}
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.goto(`/2?startVerse=10`, { waitUntil: 'domcontentloaded' });
+		await page.waitForSelector('[id="2:10"]', { timeout: 10000 });
+		const info8 = await getVerseTintInfo(page, '2:10');
+		// id 8 light 0.22 -> rgba(224,220,214,0.22)
+		expect(info8.backgroundColor).toMatch(/rgba\(224,\s*220,\s*214,\s*0\.22\)/);
+		expect(info8.styleAttr).toContain('rgba(224,220,214,0.22)');
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${test.info().project.name}_TC01_tint_light_0_28.png`, fullPage: true });
+	});
+
+	test('TC02 dark tint new rgba 0.34 visible stronger pastel', async ({ page }) => {
+		await setWebsiteTheme(page, 5);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info).not.toBeNull();
+		// FIX-006: id1 dark 0.34 -> rgba(185,151,63,0.34)
+		expect(info.backgroundColor).toMatch(/rgba\(185,\s*151,\s*63,\s*0\.34\)/);
+		expect(info.styleAttr).toContain('rgba(185,151,63,0.34)');
+		const alpha = parseFloat(info.backgroundColor.match(/rgba\(.*,\s*([0-9.]+)\)/)?.[1] || '0');
+		expect(alpha).toBeGreaterThan(0.18);
+		expect(alpha).toBeLessThan(0.4);
+		expect(info.className).not.toMatch(/bg-\[#B9973F\]/);
+		expect(info.className).toContain('rounded-xl');
+
+		// verify id8 dark 0.30
+		await page.evaluate(() => {
+			try {
+				const raw = JSON.parse(localStorage.getItem('userSettings')||'{}');
+				raw.userColoredBookmarks = { '2:10': 8 };
+				localStorage.setItem('userSettings', JSON.stringify(raw));
+			} catch {}
+		});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.goto(`/2?startVerse=10`, { waitUntil: 'domcontentloaded' });
+		await page.waitForSelector('[id="2:10"]', { timeout: 10000 });
+		const info8 = await getVerseTintInfo(page, '2:10');
+		expect(info8.backgroundColor).toMatch(/rgba\(154,\s*143,\s*134,\s*0\.3\)/);
+		expect(info8.styleAttr).toContain('rgba(154,143,134,0.3)');
+
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${test.info().project.name}_TC02_tint_dark_0_34.png`, fullPage: true });
+	});
+
+	test('TC03 all 8 tokens opacity range light 0.22-0.28 dark 0.30-0.34 hex unchanged aesthetic', async ({ page }) => {
+		// verify via helper evaluation that COLOR_TOKENS match table and hex unchanged
+		await page.goto('/', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		const tokens = await page.evaluate(async () => {
+			try {
+				const m = await import('/src/utils/coloredBookmarks.js');
+				return m.COLOR_TOKENS;
+			} catch (e) { return null; }
+		});
+		// fallback: evaluate via compiled chunk if import fails, just check computed styles for 8 ids
+		if (tokens) {
+			expect(tokens['1'].lightOpacity).toBe(0.28);
+			expect(tokens['1'].darkOpacity).toBe(0.34);
+			expect(tokens['8'].lightOpacity).toBe(0.22);
+			expect(tokens['8'].darkOpacity).toBe(0.3);
+			for (let i=1;i<=8;i++) {
+				expect(tokens[String(i)].lightOpacity).toBeGreaterThanOrEqual(0.22);
+				expect(tokens[String(i)].lightOpacity).toBeLessThanOrEqual(0.28);
+				expect(tokens[String(i)].darkOpacity).toBeGreaterThanOrEqual(0.3);
+				expect(tokens[String(i)].darkOpacity).toBeLessThanOrEqual(0.34);
+				expect(tokens[String(i)].lightOpacity).toBeLessThan(0.4);
+				expect(tokens[String(i)].darkOpacity).toBeLessThan(0.4);
+				// hex not harsh red/blue
+				expect(tokens[String(i)].lightHex).not.toMatch(/#FF0000/i);
+				expect(tokens[String(i)].darkHex).not.toMatch(/#0000FF/i);
+			}
+			// hex unchanged per spec
+			expect(tokens['1'].lightHex).toBe('#EADDB8');
+			expect(tokens['1'].darkHex).toBe('#B9973F');
+			expect(tokens['4'].lightHex).toBe('#DDD4E8');
+			expect(tokens['8'].lightHex).toBe('#E0DCD6');
+		} else {
+			// fallback style-based check: seed 8 verses each color and check computed alpha
+			await setWebsiteTheme(page, 1);
+			const map = {};
+			for (let i=1;i<=8;i++) map[`${i}:1`] = i;
+			await seedColoredBookmarks(page, map);
+			// check a couple
+			await page.goto('/1?startVerse=1', { waitUntil: 'domcontentloaded' });
+			await page.waitForSelector('[id="1:1"]', { timeout: 8000 });
+			const info1 = await getVerseTintInfo(page, '1:1');
+			expect(info1.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.28\)/);
+		}
+	});
+
+	test('TC04 grouping and accordion still works after opacity bump', async ({ page }) => {
+		await seedColoredBookmarks(page, { '1:1': 1, '2:255': 1, '36:58': 4, '114:6': 8 });
+		await gotoHomeColoredTab(page);
+		const headers = page.locator('button[id^="colored-section-"]');
+		await expect(headers).toHaveCount(8);
+		for (let id=1; id<=8; id++) {
+			await expect(page.locator(`#colored-section-${id}`)).toBeVisible();
+			await expect(page.locator(`#colored-section-${id}`)).toHaveAttribute('aria-expanded', /true|false/);
+			await expect(page.locator(`#colored-section-${id}`)).toHaveAttribute('aria-controls', `colored-panel-${id}`);
+		}
+		await expect(page.locator('#colored-section-1')).toContainText('(2)');
+		await expect(page.locator('#colored-section-4')).toContainText('(1)');
+		await expect(page.locator('#colored-section-8')).toContainText('(1)');
+		// initially hidden
+		for (let id=1; id<=8; id++) await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+		// expand Amber Glow
+		await clickAccordion(page, 1);
+		await expect(page.locator('#colored-section-1')).toHaveAttribute('aria-expanded', 'true');
+		await expect(page.locator('#colored-panel-1')).toBeVisible();
+		await expect(page.locator('#colored-panel-1')).toHaveClass(/block/);
+		// others stay hidden
+		for (let id=2; id<=8; id++) await expect(page.locator(`#colored-panel-${id}`)).toBeHidden();
+		// canonical order check
+		const links = page.locator('#colored-panel-1 a[href*="?startVerse="]');
+		await expect(links).toHaveCount(2);
+		const hrefs = await links.evaluateAll(els => els.map(e=>e.getAttribute('href')));
+		expect(hrefs[0]).toMatch(/\/1\?startVerse=1/);
+		expect(hrefs[1]).toMatch(/\/2\?startVerse=255/);
+		// empty color placeholder when expanded
+		await clickAccordion(page, 2);
+		await expect(page.locator('#colored-panel-2')).toBeVisible();
+		await expect(page.locator('#colored-panel-2').getByText('No verses in Terracotta Dune')).toBeVisible();
+		await expect(page.locator('#colored-panel-2').getByText('No verses in Terracotta Dune')).toHaveClass(/opacity-40/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${test.info().project.name}_TC04_grouping_accordion.png`, fullPage: true });
+	});
+
+	test('TC05 tint persists across reload and theme switch recomputes correctly', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const light = await getVerseTintInfo(page, '2:255');
+		expect(light.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.28\)/);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const afterReload = await getVerseTintInfo(page, '2:255');
+		expect(afterReload.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.28\)/);
+		// theme switch to dark
+		await setWebsiteTheme(page, 5);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const dark = await getVerseTintInfo(page, '2:255');
+		expect(dark.backgroundColor).toMatch(/rgba\(185,\s*151,\s*63,\s*0\.34\)/);
+		// back to light
+		await setWebsiteTheme(page, 1);
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.waitForSelector('[id="2:255"]', { timeout: 10000 });
+		const light2 = await getVerseTintInfo(page, '2:255');
+		expect(light2.backgroundColor).toMatch(/rgba\(234,\s*221,\s*184,\s*0\.28\)/);
+		await page.screenshot({ path: `${SCREENSHOT_DIR}/${test.info().project.name}_TC05_persist_theme_switch.png`, fullPage: true });
+	});
+
+	test('TC06 no Tailwind arbitrary bg class for tint, still rounded and transition, accent not harsh', async ({ page }) => {
+		await setWebsiteTheme(page, 1);
+		await seedColoredBookmarks(page, { '2:255': 1 });
+		await gotoChapterVerse(page, 2, 255);
+		const info = await getVerseTintInfo(page, '2:255');
+		expect(info.className).not.toMatch(/bg-\[#/);
+		expect(info.className).toContain('rounded-xl');
+		expect(info.className).toContain('transition-colors');
+		expect(info.borderRadius).not.toBe('0px');
+		// check computed alpha pastel
+		const alpha = parseFloat(info.backgroundColor.match(/,\s*([0-9.]+)\)/)?.[1] || '0');
+		expect(alpha).toBeLessThan(0.4);
+		// verify non-bookmarked verse has no inline bg
+		await seedColoredBookmarks(page, {});
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle').catch(()=>{});
+		await page.waitForSelector('[id="2:255"]', { timeout: 8000 });
+		const noColor = await getVerseTintInfo(page, '2:255');
+		expect(noColor.styleAttr).not.toContain('rgba');
+		expect(noColor.backgroundColor).toMatch(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+	});
+});

--- a/tests/integration/updateSettings.integration.test.js
+++ b/tests/integration/updateSettings.integration.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+// ensure localStorage polyfill early - will be set in setup.js
+function ls() {
+	return globalThis.localStorage || (typeof window !== 'undefined' ? window.localStorage : undefined) || (typeof global !== 'undefined' ? global.localStorage : undefined);
+}
+
+describe('updateSettings — userColoredBookmarks integration', () => {
+	let updateSettings;
+	let stores;
+	let defaultSettings;
+	let setUserSettings;
+	let getVerseTintWrapperClasses;
+
+	beforeEach(async () => {
+		ls()?.clear();
+		// dynamic imports after setup polyfills
+		const hooks = await import('../../src/hooks.client.js');
+		defaultSettings = hooks.defaultSettings;
+		setUserSettings = hooks.setUserSettings;
+		ls()?.clear();
+		setUserSettings(defaultSettings);
+		stores = await import('$utils/stores.js');
+		// re-sync store from fresh localStorage
+		const fresh = JSON.parse(ls().getItem('userSettings'));
+		stores.__userColoredBookmarks.set(fresh.userColoredBookmarks ?? {});
+		const mod = await import('$utils/updateSettings.js');
+		updateSettings = mod.updateSettings;
+		const cb = await import('$utils/coloredBookmarks.js');
+		getVerseTintWrapperClasses = cb.getVerseTintWrapperClasses;
+		window.umami = { track: vi.fn() };
+	});
+
+	it('AC2: set color persists and returns 200, store syncs', () => {
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		expect(res.ok).toBe(true);
+		expect(res.status).toBe(200);
+		expect(res.action).toBe('set');
+		expect(res.totalColored).toBe(1);
+		const map = get(stores.__userColoredBookmarks);
+		expect(map['2:255']).toBe(1);
+		const raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.userColoredBookmarks['2:255']).toBe(1);
+		expect(raw.userBookmarks).toEqual([]);
+	});
+
+	it('AC2: normalization leading zeros + alias', () => {
+		let res = updateSettings({ type: 'userColoredBookmarks', key: '002:005', color: 'amber' });
+		expect(res.ok).toBe(true);
+		expect(res.status).toBe(200);
+		let raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.userColoredBookmarks['2:5']).toBe(1);
+		res = updateSettings({ type: 'userColoredBookmarks', key: '36:58', color: 'lavender' });
+		expect(res.ok).toBe(true);
+		expect(JSON.parse(ls().getItem('userSettings')).userColoredBookmarks['36:58']).toBe(4);
+	});
+
+	it('idempotency: same color -> 204 noop no write', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 2 });
+		window.umami.track.mockClear();
+		const before = ls().getItem('userSettings');
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 2 });
+		expect(res.status).toBe(204);
+		expect(res.action).toBe('noop');
+		expect(ls().getItem('userSettings')).toBe(before);
+		expect(window.umami.track).not.toHaveBeenCalled();
+	});
+
+	it('replace: different color overwrites and tracks Change', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		window.umami.track.mockClear();
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 3 });
+		expect(res.status).toBe(200);
+		expect(res.action).toBe('replace');
+		expect(get(stores.__userColoredBookmarks)['2:255']).toBe(3);
+		expect(window.umami.track).toHaveBeenCalledWith(expect.stringContaining('Change'), expect.any(Object));
+	});
+
+	it('clear removes color only, bookmarks untouched', () => {
+		updateSettings({ type: 'userBookmarks', key: '2:255' });
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 5 });
+		let raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.userBookmarks).toContain('2:255');
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', clear: true });
+		expect(res.status).toBe(200);
+		expect(res.action).toBe('clear');
+		raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.userColoredBookmarks['2:255']).toBeUndefined();
+		expect(raw.userBookmarks).toContain('2:255');
+	});
+
+	it('clear on absent -> 204 noop', () => {
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', clear: true });
+		expect(res.status).toBe(204);
+		expect(res.action).toBe('noop');
+	});
+
+	it('validation: missing key -> 400', () => {
+		const res = updateSettings({ type: 'userColoredBookmarks', colorId: 1 });
+		expect(res.status).toBe(400);
+		expect(res.ok).toBe(false);
+		expect(res.error.code).toBe('VALIDATION_ERROR');
+	});
+
+	it('validation: invalid verseKey -> 400', () => {
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '115:1', colorId: 1 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:300', colorId: 1 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '', colorId: 1 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '  ', colorId: 1 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '__proto__', colorId: 1 }).status).toBe(400);
+	});
+
+	it('validation: invalid colorId -> 400', () => {
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 0 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 9 }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 'foo' }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:255', color: 'unknownColor' }).status).toBe(400);
+		expect(updateSettings({ type: 'userColoredBookmarks', key: '2:255' }).status).toBe(400);
+	});
+
+	it('bulk override atomic success', () => {
+		const res = updateSettings({ type: 'userColoredBookmarks', override: { '1:1': 1, '2:255': 3, '36:58': 5 } });
+		expect(res.status).toBe(200);
+		expect(res.totalColored).toBe(3);
+		const raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.userColoredBookmarks).toEqual({ '1:1': 1, '2:255': 3, '36:58': 5 });
+	});
+
+	it('bulk override atomic reject on any invalid entry', () => {
+		updateSettings({ type: 'userColoredBookmarks', override: { '1:1': 1 } });
+		const before = JSON.parse(ls().getItem('userSettings')).userColoredBookmarks;
+		const res = updateSettings({ type: 'userColoredBookmarks', override: { '1:1': 1, '115:1': 2 } });
+		expect(res.status).toBe(400);
+		expect(JSON.parse(ls().getItem('userSettings')).userColoredBookmarks).toEqual(before);
+	});
+
+	it('bulk override rejects __proto__ pollution', () => {
+		// Use JSON.parse to ensure __proto__ as own property, not prototype
+		const payload = JSON.parse('{"__proto__":1, "1:1":1}');
+		const res = updateSettings({ type: 'userColoredBookmarks', override: payload });
+		expect(res.status).toBe(400);
+		// Also test constructor pollution reliably
+		const res2 = updateSettings({ type: 'userColoredBookmarks', override: { 'constructor': 1, '1:1': 1 } });
+		expect(res2.status).toBe(400);
+	});
+
+	it('quota error reverts snapshot and returns 507', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '1:1', colorId: 1 });
+		const snapshot = JSON.parse(JSON.stringify(get(stores.__userColoredBookmarks)));
+		const orig = ls().setItem;
+		ls().setItem = vi.fn(() => {
+			const e = new DOMException('Quota exceeded', 'QuotaExceededError');
+			// code is getter-only in some engines, rely on name check in isQuotaError
+			throw e;
+		});
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 2 });
+		expect(res.status).toBe(507);
+		expect(res.error.code).toBe('QUOTA_EXCEEDED');
+		expect(get(stores.__userColoredBookmarks)).toEqual(snapshot);
+		ls().setItem = orig;
+	});
+
+	it('persistence survives reload: set + re-init via setUserSettings additive', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		updateSettings({ type: 'userColoredBookmarks', key: '36:58', colorId: 4 });
+		const stored = ls().getItem('userSettings');
+		setUserSettings(defaultSettings);
+		const after = JSON.parse(ls().getItem('userSettings'));
+		expect(after.userColoredBookmarks['2:255']).toBe(1);
+		expect(after.userColoredBookmarks['36:58']).toBe(4);
+		expect(typeof stored).toBe('string');
+	});
+
+	it('migration safe for old userBookmarks array', () => {
+		ls().clear();
+		ls().setItem('userSettings', JSON.stringify({ userBookmarks: ['2:255'], userNotes: {}, custom: 'keep' }));
+		setUserSettings(defaultSettings);
+		const parsed = JSON.parse(ls().getItem('userSettings'));
+		expect(parsed.userBookmarks).toEqual(['2:255']);
+		expect(parsed.userColoredBookmarks).toEqual({});
+		expect(parsed.custom).toBe('keep');
+	});
+
+	it('store -> wrapper tint integration: getVerseTintWrapperClasses uses stored color', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		const cid = get(stores.__userColoredBookmarks)['2:255'];
+		expect(getVerseTintWrapperClasses(cid, 1, false)).toContain('bg-[');
+	});
+
+	it('wrapper tint picks dark vs light correctly', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		const cid = get(stores.__userColoredBookmarks)['2:255'];
+		expect(getVerseTintWrapperClasses(cid, 1, false)).toBe('bg-[#EADDB8]/28 rounded-xl transition-colors duration-200');
+		expect(getVerseTintWrapperClasses(cid, 5, false)).toBe('bg-[#B9973F]/34 rounded-xl transition-colors duration-200');
+		expect(getVerseTintWrapperClasses(cid, 5, true)).toContain('box-decoration-clone');
+	});
+
+	it('homepage grouping derived from store (canonical order)', () => {
+		updateSettings({ type: 'userColoredBookmarks', key: '36:58', colorId: 4 });
+		updateSettings({ type: 'userColoredBookmarks', key: '1:1', colorId: 1 });
+		updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		const map = get(stores.__userColoredBookmarks);
+		expect(map['1:1']).toBe(1);
+		const byColor = { 1: [], 4: [] };
+		for (const [k, v] of Object.entries(map)) {
+			if (v === 1) byColor[1].push(k);
+			if (v === 4) byColor[4].push(k);
+		}
+		byColor[1].sort((a, b) => {
+			const [ca, va] = a.split(':').map(Number);
+			const [cb, vb] = b.split(':').map(Number);
+			return ca !== cb ? ca - cb : va - vb;
+		});
+		expect(byColor[1]).toEqual(['1:1', '2:255']);
+		expect(byColor[4]).toEqual(['36:58']);
+	});
+
+	it('extrasActiveTab 4 persists', () => {
+		const res = updateSettings({ type: 'homepageLayoutPreferences', value: { extrasPanelVisible: true, divisionsActiveTab: 1, extrasActiveTab: 4, chaptersSortIsAscending: true, juzSortIsAscending: true, hizbSortIsAscending: true } });
+		expect(res.ok).toBe(true);
+		const raw = JSON.parse(ls().getItem('userSettings'));
+		expect(raw.displaySettings.homepageLayoutPreferences.extrasActiveTab).toBe(4);
+	});
+
+	it('empty/boundary: handles invalid JSON in localStorage gracefully via setUserSettings', () => {
+		ls().setItem('userSettings', JSON.stringify({ userColoredBookmarks: [], userBookmarks: [] }));
+		const res = updateSettings({ type: 'userColoredBookmarks', key: '2:255', colorId: 1 });
+		expect(res.ok).toBe(true);
+		expect(JSON.parse(ls().getItem('userSettings')).userColoredBookmarks['2:255']).toBe(1);
+	});
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,99 @@
+import { vi } from 'vitest';
+
+// In-memory localStorage polyfill ensuring bare `localStorage` works in hooks.client.js
+function createMemoryStorage() {
+	let store = {};
+	return {
+		getItem(k) { return store[k] ?? null; },
+		setItem(k, v) { store[k] = String(v); },
+		removeItem(k) { delete store[k]; },
+		clear() { store = {}; },
+		key(n) { return Object.keys(store)[n] ?? null; },
+		get length() { return Object.keys(store).length; }
+	};
+}
+const memStorage = createMemoryStorage();
+
+// Polyfill global localStorage for jsdom consistency - ensure bare `localStorage` works in hooks.client.js
+if (typeof window !== 'undefined') {
+	if (!window.localStorage) window.localStorage = memStorage;
+	if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = window.localStorage;
+	if (typeof global !== 'undefined' && typeof global.localStorage === 'undefined') global.localStorage = window.localStorage;
+	// also alias bare localStorage if not defined
+	try {
+		if (typeof localStorage === 'undefined') globalThis.localStorage = window.localStorage;
+	} catch (_e) { /* ignore */ }
+	// ensure all point to same mock
+	if (globalThis.localStorage !== window.localStorage) {
+		// prefer window storage but sync
+		globalThis.localStorage = window.localStorage;
+	}
+	if (typeof global !== 'undefined' && global.localStorage !== window.localStorage) {
+		global.localStorage = window.localStorage;
+	}
+} else {
+	// no window (node), ensure global has storage
+	if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = memStorage;
+	if (typeof global !== 'undefined' && typeof global.localStorage === 'undefined') global.localStorage = memStorage;
+}
+
+// Stub matchMedia for hooks.client.js defaultSettings
+if (typeof window !== 'undefined') {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+}
+if (typeof globalThis.matchMedia === 'undefined' && typeof window !== 'undefined' && window.matchMedia) {
+	globalThis.matchMedia = window.matchMedia;
+}
+if (typeof global !== 'undefined' && typeof global.matchMedia === 'undefined' && typeof window !== 'undefined' && window.matchMedia) {
+	global.matchMedia = window.matchMedia;
+}
+
+// jsdom already provides localStorage but ensure clean state before each test
+beforeEach(() => {
+	// ensure storage polyfill sync per test (jsdom creates fresh window each test)
+	if (typeof window !== 'undefined') {
+		if (!window.localStorage) window.localStorage = memStorage;
+		if (globalThis.localStorage !== window.localStorage) globalThis.localStorage = window.localStorage;
+		if (typeof global !== 'undefined' && global.localStorage !== window.localStorage) global.localStorage = window.localStorage;
+		// bare localStorage alias
+		try { if (typeof localStorage === 'undefined') globalThis.localStorage = window.localStorage; } catch (_e) { /* ignore */ }
+	}
+	if (typeof globalThis.localStorage === 'undefined' && typeof global !== 'undefined' && global.localStorage) {
+		globalThis.localStorage = global.localStorage;
+	}
+	try {
+		globalThis.localStorage?.clear();
+	} catch (_e) { /* ignore */ }
+	try {
+		window?.localStorage?.clear();
+	} catch (_e) { /* ignore */ }
+	try {
+		global?.localStorage?.clear();
+	} catch (_e) { /* ignore */ }
+	vi.clearAllMocks();
+	// default umami stub
+	if (typeof window !== 'undefined') {
+		window.umami = window.umami || { track: vi.fn() };
+		window.umami.track = vi.fn();
+	}
+	globalThis.window = globalThis.window || window || {};
+	if (!globalThis.window.umami) globalThis.window.umami = { track: vi.fn() };
+	else globalThis.window.umami.track = vi.fn();
+});
+
+// Provide stable quranMetaData mock via vitest manual mock?
+// We'll let actual file be imported; quranMetaData is large but valid.
+
+globalThis.__svelteMocks = {};

--- a/tests/unit/coloredBookmarks.unit.test.js
+++ b/tests/unit/coloredBookmarks.unit.test.js
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock stores module before importing coloredBookmarks
+vi.mock('$utils/stores', async () => {
+	const { writable } = await import('svelte/store');
+	return {
+		__userColoredBookmarks: writable({}),
+		__websiteTheme: writable(1)
+	};
+});
+
+vi.mock('$utils/validateKey', async () => {
+	const actual = await vi.importActual('$utils/validateKey');
+	return {
+		...actual,
+		isValidVerseKey: actual.isValidVerseKey
+	};
+});
+
+import { __userColoredBookmarks } from '$utils/stores';
+import {
+	COLOR_TOKENS,
+	VALID_COLOR_IDS,
+	isValidColorId,
+	isDarkTheme,
+	getColorForVerse,
+	getVersesByColor,
+	getColoredBookmarksGrouped,
+	getTotalColoredCount,
+	getPerColorCounts,
+	hasColor,
+	getAllColoredKeysSorted,
+	getVerseTintClasses,
+	getVerseTintWrapperClasses,
+	getCardBorderColor,
+	resolveColorAlias,
+	hexToRgb,
+	getVerseTintStyle
+} from '$utils/coloredBookmarks';
+
+describe('coloredBookmarks — palette tokens', () => {
+	it('exports 8 tokens with required fields', () => {
+		expect(Object.keys(COLOR_TOKENS)).toHaveLength(8);
+		for (let i = 1; i <= 8; i++) {
+			const t = COLOR_TOKENS[i];
+			expect(t).toBeDefined();
+			expect(t.id).toBe(i);
+			expect(t.name).toMatch(/\w+/);
+			expect(t.lightHex).toMatch(/^#[0-9A-Fa-f]{6}$/);
+			expect(t.darkHex).toMatch(/^#[0-9A-Fa-f]{6}$/);
+			expect(typeof t.lightOpacity).toBe('number');
+			expect(typeof t.darkOpacity).toBe('number');
+			// FIX-006 bumped opacities: light 0.22-0.28 / dark 0.30-0.34 (was 0.10-0.18)
+			expect(t.lightOpacity).toBeGreaterThanOrEqual(0.22);
+			expect(t.lightOpacity).toBeLessThanOrEqual(0.28);
+			expect(t.darkOpacity).toBeGreaterThanOrEqual(0.3);
+			expect(t.darkOpacity).toBeLessThanOrEqual(0.34);
+			// aesthetic: still pastel translucent, alpha <0.4 not harsh/saturated
+			expect(t.lightOpacity).toBeLessThan(0.4);
+			expect(t.darkOpacity).toBeLessThan(0.4);
+		}
+	});
+
+	it('matches spec hex values', () => {
+		expect(COLOR_TOKENS[1].lightHex).toBe('#EADDB8');
+		expect(COLOR_TOKENS[1].darkHex).toBe('#B9973F');
+		expect(COLOR_TOKENS[4].lightHex).toBe('#DDD4E8');
+		expect(COLOR_TOKENS[8].lightHex).toBe('#E0DCD6');
+		expect(COLOR_TOKENS[8].lightOpacity).toBe(0.22);
+		// FIX-006 exact opacities per token (hex unchanged, opacity bumped)
+		expect(COLOR_TOKENS[1].lightOpacity).toBe(0.28); expect(COLOR_TOKENS[1].darkOpacity).toBe(0.34);
+		expect(COLOR_TOKENS[2].lightOpacity).toBe(0.26); expect(COLOR_TOKENS[2].darkOpacity).toBe(0.32);
+		expect(COLOR_TOKENS[3].lightOpacity).toBe(0.24); expect(COLOR_TOKENS[3].darkOpacity).toBe(0.3);
+		expect(COLOR_TOKENS[4].lightOpacity).toBe(0.26); expect(COLOR_TOKENS[4].darkOpacity).toBe(0.32);
+		expect(COLOR_TOKENS[5].lightOpacity).toBe(0.26); expect(COLOR_TOKENS[5].darkOpacity).toBe(0.32);
+		expect(COLOR_TOKENS[6].lightOpacity).toBe(0.24); expect(COLOR_TOKENS[6].darkOpacity).toBe(0.3);
+		expect(COLOR_TOKENS[7].lightOpacity).toBe(0.24); expect(COLOR_TOKENS[7].darkOpacity).toBe(0.3);
+		expect(COLOR_TOKENS[8].darkOpacity).toBe(0.3);
+		// aesthetic: not harsh saturated primaries
+		for (let i = 1; i <= 8; i++) {
+			expect(COLOR_TOKENS[i].lightHex.toUpperCase()).not.toBe('#FF0000');
+			expect(COLOR_TOKENS[i].darkHex.toUpperCase()).not.toBe('#0000FF');
+		}
+	});
+
+	it('VALID_COLOR_IDS contains 1..8', () => {
+		expect(VALID_COLOR_IDS.size).toBe(8);
+		for (let i = 1; i <= 8; i++) expect(VALID_COLOR_IDS.has(i)).toBe(true);
+		expect(VALID_COLOR_IDS.has(0)).toBe(false);
+		expect(VALID_COLOR_IDS.has(9)).toBe(false);
+	});
+});
+
+describe('isValidColorId', () => {
+	it.each([
+		[1, true],
+		[8, true],
+		['1', true],
+		['8', true],
+		[0, false],
+		[9, false],
+		[null, false],
+		[undefined, false],
+		['foo', false],
+		[1.5, false],
+		[NaN, false]
+	])('isValidColorId(%p) -> %p', (input, expected) => {
+		expect(isValidColorId(input)).toBe(expected);
+	});
+});
+
+describe('isDarkTheme', () => {
+	it('detects dark themes 5-9', () => {
+		expect(isDarkTheme(1)).toBe(false);
+		expect(isDarkTheme(4)).toBe(false);
+		expect(isDarkTheme(5)).toBe(true);
+		expect(isDarkTheme(6)).toBe(true);
+		expect(isDarkTheme(9)).toBe(true);
+		expect(isDarkTheme('5')).toBe(true);
+		expect(isDarkTheme(10)).toBe(false);
+	});
+});
+
+describe('getVerseTintClasses', () => {
+	it('returns empty for invalid colorId', () => {
+		expect(getVerseTintClasses(0, 1)).toBe('');
+		expect(getVerseTintClasses(9, 1)).toBe('');
+		expect(getVerseTintClasses(null, 1)).toBe('');
+	});
+	it('returns light token for theme 1', () => {
+		expect(getVerseTintClasses(1, 1)).toBe('bg-[#EADDB8]/28');
+		expect(getVerseTintClasses(3, 2)).toBe('bg-[#E5D1D1]/24');
+		expect(getVerseTintClasses(8, 1)).toBe('bg-[#E0DCD6]/22');
+	});
+	it('returns dark token for theme 5', () => {
+		expect(getVerseTintClasses(1, 5)).toBe('bg-[#B9973F]/34');
+		expect(getVerseTintClasses(4, 6)).toBe('bg-[#8E7AAE]/32');
+		expect(getVerseTintClasses(5, 9)).toBe('bg-[#7A9AB5]/32');
+	});
+	it('handles string colorId', () => {
+		expect(getVerseTintClasses('2', 1)).toBe('bg-[#E6D0C0]/26');
+	});
+});
+
+describe('getVerseTintWrapperClasses', () => {
+	it('returns empty for falsy colorId', () => {
+		expect(getVerseTintWrapperClasses(null, 1)).toBe('');
+		expect(getVerseTintWrapperClasses(0, 1)).toBe('');
+	});
+	it('block vs inline classes', () => {
+		const block = getVerseTintWrapperClasses(1, 1, false);
+		expect(block).toContain('bg-[#EADDB8]/28');
+		expect(block).toContain('rounded-xl');
+		expect(block).not.toContain('box-decoration-clone');
+		const inline = getVerseTintWrapperClasses(1, 1, true);
+		expect(inline).toContain('box-decoration-clone');
+		expect(inline).toContain('rounded-lg');
+		expect(inline).toContain('px-1.5');
+	});
+	it('transitions present', () => {
+		expect(getVerseTintWrapperClasses(2, 5, false)).toContain('transition-colors');
+	});
+});
+
+describe('getCardBorderColor', () => {
+	it('returns light/dark hex', () => {
+		expect(getCardBorderColor(1, 1)).toBe('#EADDB8');
+		expect(getCardBorderColor(1, 5)).toBe('#B9973F');
+		expect(getCardBorderColor(9, 1)).toBe('');
+	});
+});
+
+describe('hexToRgb', () => {
+	it('parses 6-char hex with and without #', () => {
+		expect(hexToRgb('#EADDB8')).toEqual({ r: 234, g: 221, b: 184 });
+		expect(hexToRgb('B9973F')).toEqual({ r: 185, g: 151, b: 63 });
+		expect(hexToRgb('#E6D0C0')).toEqual({ r: 230, g: 208, b: 192 });
+	});
+	it('expands 3-char hex', () => {
+		expect(hexToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 });
+		expect(hexToRgb('fff')).toEqual({ r: 255, g: 255, b: 255 });
+	});
+	it('trims and handles case', () => {
+		expect(hexToRgb('  #eaddb8  ')).toEqual({ r: 234, g: 221, b: 184 });
+	});
+	it('returns null for invalid', () => {
+		expect(hexToRgb('')).toBeNull();
+		expect(hexToRgb(null)).toBeNull();
+		expect(hexToRgb('#GGGGGG')).toBeNull();
+		expect(hexToRgb('#1234')).toBeNull();
+		expect(hexToRgb('#12')).toBeNull();
+	});
+});
+
+describe('getVerseTintStyle — FIX-004 inline rgba', () => {
+	it('returns empty for invalid colorId', () => {
+		expect(getVerseTintStyle(0, 1)).toBe('');
+		expect(getVerseTintStyle(9, 1)).toBe('');
+		expect(getVerseTintStyle(null, 1)).toBe('');
+		expect(getVerseTintStyle(undefined, 5)).toBe('');
+	});
+	it('light theme 1 uses lightHex and lightOpacity', () => {
+		expect(getVerseTintStyle(1, 1)).toBe('background-color: rgba(234,221,184,0.28)');
+		expect(getVerseTintStyle(2, 2)).toBe('background-color: rgba(230,208,192,0.26)');
+		expect(getVerseTintStyle(3, 1)).toBe('background-color: rgba(229,209,209,0.24)');
+		expect(getVerseTintStyle(8, 1)).toBe('background-color: rgba(224,220,214,0.22)');
+	});
+	it('dark theme 5-9 uses darkHex and darkOpacity', () => {
+		expect(getVerseTintStyle(1, 5)).toBe('background-color: rgba(185,151,63,0.34)');
+		expect(getVerseTintStyle(1, 6)).toBe('background-color: rgba(185,151,63,0.34)');
+		expect(getVerseTintStyle(2, 5)).toBe('background-color: rgba(192,122,90,0.32)');
+		expect(getVerseTintStyle(4, 9)).toBe('background-color: rgba(142,122,174,0.32)');
+		expect(getVerseTintStyle(8, 5)).toBe('background-color: rgba(154,143,134,0.3)');
+	});
+	it('handles string colorId and string theme', () => {
+		expect(getVerseTintStyle('1', '1')).toBe('background-color: rgba(234,221,184,0.28)');
+		expect(getVerseTintStyle('1', '5')).toBe('background-color: rgba(185,151,63,0.34)');
+	});
+	it('never returns Tailwind bg class', () => {
+		expect(getVerseTintStyle(1, 1)).not.toContain('bg-[');
+		expect(getVerseTintStyle(1, 5)).not.toContain('bg-[');
+	});
+});
+
+describe('COLOR_ALIAS_MAP / resolveColorAlias', () => {
+	it('resolves numeric strings 1..8', () => {
+		expect(resolveColorAlias('1')).toBe(1);
+		expect(resolveColorAlias('8')).toBe(8);
+		expect(resolveColorAlias(3)).toBe(3);
+	});
+	it('resolves aliases case-insensitive & dashed', () => {
+		expect(resolveColorAlias('amber')).toBe(1);
+		expect(resolveColorAlias('Amber Glow')).toBe(null); // space not in map, but trimmed lower: amber glow? check spec: space not allowed, but alias map has amberglow
+		expect(resolveColorAlias('amberglow')).toBe(1);
+		expect(resolveColorAlias('amber-glow')).toBe(1);
+		expect(resolveColorAlias('Terracotta')).toBe(2);
+		expect(resolveColorAlias('lavender-mist')).toBe(4);
+		expect(resolveColorAlias('slate')).toBe(5);
+		expect(resolveColorAlias('sage')).toBe(6);
+		expect(resolveColorAlias('olive')).toBe(7);
+		expect(resolveColorAlias('stone')).toBe(8);
+		expect(resolveColorAlias('taupe')).toBe(8);
+	});
+	it('returns null for invalid', () => {
+		expect(resolveColorAlias('foo')).toBeNull();
+		expect(resolveColorAlias('9')).toBeNull();
+		expect(resolveColorAlias(null)).toBeNull();
+	});
+	it('trims whitespace', () => {
+		expect(resolveColorAlias('  amber  ')).toBe(1);
+	});
+});
+
+describe('getColorForVerse + helpers with store', () => {
+	beforeEach(() => {
+		__userColoredBookmarks.set({});
+		(globalThis.localStorage || window.localStorage)?.clear?.();
+		(globalThis.localStorage || window.localStorage)?.setItem('userSettings', JSON.stringify({ userColoredBookmarks: {} }));
+	});
+
+	it('returns null for invalid keys', () => {
+		expect(getColorForVerse('')).toBeNull();
+		expect(getColorForVerse('  ')).toBeNull();
+		expect(getColorForVerse('115:1')).toBeNull(); // chapter out of range
+		expect(getColorForVerse('2:300')).toBeNull(); // verse out of range (2 has 286)
+		expect(getColorForVerse('bad')).toBeNull();
+		expect(getColorForVerse(null)).toBeNull();
+		expect(getColorForVerse(undefined)).toBeNull();
+	});
+
+	it('normalizes leading zeros 002:005 -> 2:5', () => {
+		__userColoredBookmarks.set({ '2:5': 3 });
+		expect(getColorForVerse('002:005')).toBe(3);
+		expect(getColorForVerse('02:05')).toBe(3);
+	});
+
+	it('reads from store', () => {
+		__userColoredBookmarks.set({ '2:255': 1, '36:58': 4 });
+		expect(getColorForVerse('2:255')).toBe(1);
+		expect(getColorForVerse('36:58')).toBe(4);
+		expect(getColorForVerse('1:1')).toBeNull();
+	});
+
+	it('falls back to localStorage when store empty/corrupt', () => {
+		// simulate SSR where store throws? we set store to invalid but localStorage has data
+		__userColoredBookmarks.set(null);
+		const payload = JSON.stringify({ userColoredBookmarks: { '2:255': 2 } });
+		try { globalThis.localStorage?.setItem('userSettings', payload); } catch (_e) { /* ignore */ }
+		try { window.localStorage?.setItem('userSettings', payload); } catch (_e) { /* ignore */ }
+		try { global.localStorage?.setItem('userSettings', payload); } catch (_e) { /* ignore */ }
+		// ensure bare localStorage also set if exists
+		try { localStorage?.setItem('userSettings', payload); } catch (_e) { /* ignore */ }
+		// readMap tries store then localStorage
+		expect(getColorForVerse('2:255')).toBe(2);
+	});
+
+	it('filters invalid colorId values in map', () => {
+		__userColoredBookmarks.set({ '2:255': 9, '2:256': 0, '2:257': 1 });
+		expect(getColorForVerse('2:255')).toBeNull();
+		expect(getColorForVerse('2:257')).toBe(1);
+	});
+
+	it('hasColor boolean', () => {
+		__userColoredBookmarks.set({ '2:255': 1 });
+		expect(hasColor('2:255')).toBe(true);
+		expect(hasColor('2:256')).toBe(false);
+	});
+
+	it('handles corrupted localStorage JSON gracefully', () => {
+		__userColoredBookmarks.set({});
+		// corrupt not needed because store returns {}
+		expect(getColorForVerse('2:255')).toBeNull();
+		// simulate corrupted localStorage with store not available: we set store to throw
+		// already covered fallback returns {}
+	});
+});
+
+describe('getVersesByColor', () => {
+	beforeEach(() => {
+		__userColoredBookmarks.set({
+			'2:255': 1,
+			'1:1': 1,
+			'36:58': 4,
+			'2:10': 1,
+			'114:6': 8
+		});
+	});
+
+	it('invalid colorId -> []', () => {
+		expect(getVersesByColor(0)).toEqual([]);
+		expect(getVersesByColor(9)).toEqual([]);
+		expect(getVersesByColor('foo')).toEqual([]);
+	});
+
+	it('filters by color and sorts canonical', () => {
+		expect(getVersesByColor(1)).toEqual(['1:1', '2:10', '2:255']);
+		expect(getVersesByColor(4)).toEqual(['36:58']);
+		expect(getVersesByColor(8)).toEqual(['114:6']);
+		expect(getVersesByColor('1')).toEqual(['1:1', '2:10', '2:255']);
+	});
+
+	it('ignores invalid verseKeys in map', () => {
+		__userColoredBookmarks.set({ '115:1': 1, '2:255': 1, 'bad': 1 });
+		expect(getVersesByColor(1)).toEqual(['2:255']);
+	});
+});
+
+describe('getColoredBookmarksGrouped', () => {
+	beforeEach(() => {
+		__userColoredBookmarks.set({});
+	});
+
+	it('empty map -> isEmpty true', () => {
+		const g = getColoredBookmarksGrouped();
+		expect(g.isEmpty).toBe(true);
+		expect(g.counts.total).toBe(0);
+		expect(g.all).toEqual([]);
+		for (let i = 1; i <= 8; i++) expect(g.byColor[i]).toEqual([]);
+	});
+
+	it('groups and counts correctly canonical order', () => {
+		__userColoredBookmarks.set({ '36:58': 4, '2:255': 1, '1:1': 1, '2:10': 1, '114:6': 1 });
+		const { byColor, all, counts, isEmpty } = getColoredBookmarksGrouped();
+		expect(isEmpty).toBe(false);
+		expect(all).toEqual(['1:1', '2:10', '2:255', '36:58', '114:6']);
+		expect(byColor[1]).toEqual(['1:1', '2:10', '2:255', '114:6']);
+		expect(byColor[4]).toEqual(['36:58']);
+		expect(byColor[2]).toEqual([]);
+		expect(counts.total).toBe(5);
+		expect(counts.byColor[1]).toBe(4);
+		expect(counts.byColor[4]).toBe(1);
+	});
+
+	it('ignores invalid entries', () => {
+		__userColoredBookmarks.set({ '2:255': 9, '115:1': 1, '2:10': 1, 'bad': 2 });
+		const g = getColoredBookmarksGrouped();
+		expect(g.counts.total).toBe(1);
+		expect(g.byColor[1]).toEqual(['2:10']);
+	});
+
+	it('getTotalColoredCount / getPerColorCounts / getAllColoredKeysSorted wrappers', () => {
+		__userColoredBookmarks.set({ '2:255': 1, '36:58': 4 });
+		expect(getTotalColoredCount()).toBe(2);
+		expect(getPerColorCounts()[1]).toBe(1);
+		expect(getPerColorCounts()[4]).toBe(1);
+		expect(getAllColoredKeysSorted()).toEqual(['2:255', '36:58']);
+	});
+
+	it('canonical sort across chapters', () => {
+		__userColoredBookmarks.set({ '3:1': 2, '2:286': 2, '2:1': 2, '114:6': 2 });
+		expect(getVersesByColor(2)).toEqual(['2:1', '2:286', '3:1', '114:6']);
+	});
+
+	it('boundary values: 6236 entries not required but map size', () => {
+		const bulk = {};
+		for (let i = 1; i <= 10; i++) bulk[`${i}:1`] = ((i % 8) + 1);
+		__userColoredBookmarks.set(bulk);
+		const g = getColoredBookmarksGrouped();
+		expect(g.counts.total).toBe(10);
+	});
+});


### PR DESCRIPTION
- Colored Bookmarks is available under Options menu of each ayah.
- Once a color selected, the ayah's background color changes to the color.
- Colored bookmarks are shown at Homepage, classified for each color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added colored bookmarks with eight selectable colors, including options to update, replace, and clear colors.
  * Added color-tinted verse displays across reading layouts with light and dark theme support.
  * Added a homepage Colored Bookmarks tab with grouped, sortable, keyboard-accessible accordion sections.
  * Added bookmark persistence, validation, empty states, and Arabic verse text loading.

* **Bug Fixes**
  * Improved bookmark color persistence, malformed-data recovery, accessibility, focus handling, and reduced-motion behavior.

* **Tests**
  * Added comprehensive unit, integration, and end-to-end coverage for colored bookmark workflows and themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->